### PR TITLE
[SITIONIX-90] - implement bff cookie session auth flow

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.12</bffssox.api.version>
+        <bffssox.api.version>0.0.13</bffssox.api.version>
     </properties>
 
     <dependencies>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AuthController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AuthController.java
@@ -8,27 +8,39 @@ import com.app_afesox.bffssox.api_first.dto.LoginResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.RefreshAccessTokenRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.RefreshAccessTokenResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ResendEmailVerificationResponseDTO;
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
+import com.sitionix.bffssox.domain.BffResolvedSession;
 import com.sitionix.bffssox.domain.EmailVerificationRequest;
 import com.sitionix.bffssox.domain.EmailVerificationResponse;
+import com.sitionix.bffssox.domain.BffSessionProperties;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
 import com.sitionix.bffssox.domain.RefreshAccessTokenRequest;
 import com.sitionix.bffssox.domain.RefreshAccessTokenResponse;
 import com.sitionix.bffssox.domain.ResendEmailVerificationResponse;
+import com.sitionix.bffssox.domain.SessionResponse;
+import com.sitionix.bffssox.domain.SessionCookieManager;
+import com.sitionix.bffssox.domain.SessionUser;
 import com.sitionix.bffssox.mapper.EmailVerificationApiMapper;
 import com.sitionix.bffssox.mapper.LoginUserApiMapper;
 import com.sitionix.bffssox.mapper.RefreshAccessTokenApiMapper;
 import com.sitionix.bffssox.mapper.ResendEmailVerificationApiMapper;
+import com.sitionix.bffssox.usecase.GetSession;
 import com.sitionix.bffssox.usecase.LoginUser;
 import com.sitionix.bffssox.usecase.RefreshAccessToken;
 import com.sitionix.bffssox.usecase.ResendEmailVerification;
 import com.sitionix.bffssox.usecase.VerifyEmail;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,6 +49,8 @@ public class AuthController implements AuthApi {
     private final LoginUserApiMapper loginUserApiMapper;
 
     private final LoginUser loginUser;
+
+    private final GetSession getSession;
 
     private final EmailVerificationApiMapper emailVerificationApiMapper;
 
@@ -50,14 +64,46 @@ public class AuthController implements AuthApi {
 
     private final ResendEmailVerification resendEmailVerification;
 
+    private final SessionCookieManager sessionCookieManager;
+
+    private final BffSessionProperties bffSessionProperties;
+
+    @Override
+    public ResponseEntity<LoginResponseDTO> getSession() {
+        final String sessionId = this.readSessionId().orElse(null);
+        final Optional<BffResolvedSession> resolvedSession = this.getSession.execute(
+                sessionId,
+                this.readUserAgent(),
+                this.readRemoteAddress()
+        );
+        if (resolvedSession.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .header(HttpHeaders.SET_COOKIE, this.sessionCookieManager.clearSessionCookie())
+                    .header(HttpHeaders.SET_COOKIE, this.sessionCookieManager.clearCsrfCookie())
+                    .body(new LoginResponseDTO().authenticated(Boolean.FALSE));
+        }
+        final BffResolvedSession session = resolvedSession.get();
+        final SessionResponse response = this.toLoginResponse(session);
+        final ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, this.sessionCookieManager.createCsrfCookie(session.getSession().getCsrfToken()));
+        if (session.getPreviousSessionId() != null) {
+            responseBuilder.header(HttpHeaders.SET_COOKIE, this.sessionCookieManager.createSessionCookie(session.getSessionId()));
+        }
+        return responseBuilder.body(this.loginUserApiMapper.asLoginResponseDTO(response));
+    }
+
     @Override
     public ResponseEntity<LoginResponseDTO> login(@Valid final LoginRequestDTO loginRequestDTO) {
         final LoginRequest loginRequest = this.loginUserApiMapper.asLoginRequest(loginRequestDTO);
-
-        final LoginResponse response = this.loginUser.execute(loginRequest);
-
+        final BffLoginSessionResult response = this.loginUser.execute(
+                loginRequest,
+                this.readUserAgent(),
+                this.readRemoteAddress()
+        );
         return ResponseEntity.status(HttpStatus.OK)
-                .body(this.loginUserApiMapper.asLoginResponseDTO(response));
+                .header(HttpHeaders.SET_COOKIE, this.sessionCookieManager.createSessionCookie(response.getSessionId()))
+                .header(HttpHeaders.SET_COOKIE, this.sessionCookieManager.createCsrfCookie(response.getCsrfToken()))
+                .body(this.loginUserApiMapper.asLoginResponseDTO(response.getResponse()));
     }
 
     @Override
@@ -89,5 +135,49 @@ public class AuthController implements AuthApi {
         final ResendEmailVerificationResponse response = this.resendEmailVerification.execute();
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .body(this.resendEmailVerificationApiMapper.asResendEmailVerificationResponseDTO(response));
+    }
+
+    private SessionResponse toLoginResponse(final BffResolvedSession resolvedSession) {
+        return SessionResponse.builder()
+                .authenticated(Boolean.TRUE)
+                .user(SessionUser.builder()
+                        .id(resolvedSession.getSession().getUserId())
+                        .email(resolvedSession.getSession().getEmail())
+                        .role(resolvedSession.getSession().getRole())
+                        .siteId(resolvedSession.getSession().getSiteId())
+                        .build())
+                .expiresAt(resolvedSession.getSession().getMaxExpiresAt())
+                .idleTimeoutSeconds(this.bffSessionProperties.getIdleTimeoutSeconds())
+                .build();
+    }
+
+    private Optional<String> readSessionId() {
+        final ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null || attributes.getRequest().getCookies() == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(attributes.getRequest().getCookies())
+                .filter(cookie -> this.sessionCookieManager.sessionCookieName().equals(cookie.getName()))
+                .map(jakarta.servlet.http.Cookie::getValue)
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst();
+    }
+
+    private String readUserAgent() {
+        final ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            return "";
+        }
+        final String value = attributes.getRequest().getHeader(HttpHeaders.USER_AGENT);
+        return value == null ? "" : value;
+    }
+
+    private String readRemoteAddress() {
+        final ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            return "";
+        }
+        final String value = attributes.getRequest().getRemoteAddr();
+        return value == null ? "" : value;
     }
 }

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/LoginUserApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/LoginUserApiMapper.java
@@ -3,13 +3,21 @@ package com.sitionix.bffssox.mapper;
 import com.app_afesox.bffssox.api_first.dto.LoginRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.LoginResponseDTO;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
+import com.sitionix.bffssox.domain.SessionResponse;
 import org.mapstruct.Mapper;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @Mapper(componentModel = "spring")
 public interface LoginUserApiMapper {
 
     LoginRequest asLoginRequest(final LoginRequestDTO src);
 
-    LoginResponseDTO asLoginResponseDTO(final LoginResponse src);
+    LoginResponseDTO asLoginResponseDTO(final SessionResponse src);
+
+    default OffsetDateTime asOffsetDateTime(final Instant value) {
+        return value == null ? null : value.atOffset(ZoneOffset.UTC);
+    }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AuthControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AuthControllerTest.java
@@ -7,29 +7,44 @@ import com.app_afesox.bffssox.api_first.dto.LoginResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.RefreshAccessTokenRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.RefreshAccessTokenResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ResendEmailVerificationResponseDTO;
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSession;
+import com.sitionix.bffssox.domain.BffSessionProperties;
 import com.sitionix.bffssox.domain.EmailVerificationRequest;
 import com.sitionix.bffssox.domain.EmailVerificationResponse;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
 import com.sitionix.bffssox.domain.RefreshAccessTokenRequest;
 import com.sitionix.bffssox.domain.RefreshAccessTokenResponse;
 import com.sitionix.bffssox.domain.ResendEmailVerificationResponse;
+import com.sitionix.bffssox.domain.SessionCookieManager;
+import com.sitionix.bffssox.domain.SessionResponse;
 import com.sitionix.bffssox.mapper.EmailVerificationApiMapper;
 import com.sitionix.bffssox.mapper.LoginUserApiMapper;
 import com.sitionix.bffssox.mapper.RefreshAccessTokenApiMapper;
 import com.sitionix.bffssox.mapper.ResendEmailVerificationApiMapper;
+import com.sitionix.bffssox.usecase.GetSession;
 import com.sitionix.bffssox.usecase.LoginUser;
 import com.sitionix.bffssox.usecase.RefreshAccessToken;
 import com.sitionix.bffssox.usecase.ResendEmailVerification;
 import com.sitionix.bffssox.usecase.VerifyEmail;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -49,6 +64,9 @@ class AuthControllerTest {
     private VerifyEmail verifyEmail;
 
     @Mock
+    private GetSession getSession;
+
+    @Mock
     private RefreshAccessToken refreshAccessToken;
 
     @Mock
@@ -63,24 +81,35 @@ class AuthControllerTest {
     @Mock
     private ResendEmailVerification resendEmailVerification;
 
+    @Mock
+    private SessionCookieManager sessionCookieManager;
+
+    @Mock
+    private BffSessionProperties bffSessionProperties;
+
     @BeforeEach
     void setUp() {
-        this.authController = new AuthController(this.mapper, this.loginUser,
+        this.authController = new AuthController(this.mapper, this.loginUser, this.getSession,
                 this.emailVerificationApiMapper, this.verifyEmail,
                 this.refreshAccessTokenApiMapper, this.refreshAccessToken,
-                this.resendEmailVerificationApiMapper, this.resendEmailVerification);
+                this.resendEmailVerificationApiMapper, this.resendEmailVerification,
+                this.sessionCookieManager, this.bffSessionProperties);
     }
 
     @AfterEach
     void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
         verifyNoMoreInteractions(this.loginUser,
                 this.mapper,
                 this.verifyEmail,
+                this.getSession,
                 this.refreshAccessToken,
                 this.emailVerificationApiMapper,
                 this.refreshAccessTokenApiMapper,
                 this.resendEmailVerificationApiMapper,
-                this.resendEmailVerification);
+                this.resendEmailVerification,
+                this.sessionCookieManager,
+                this.bffSessionProperties);
     }
 
     @Test
@@ -88,24 +117,95 @@ class AuthControllerTest {
         //given
         final LoginRequestDTO loginRequestDTO = mock(LoginRequestDTO.class);
         final LoginResponseDTO loginResponseDTO = mock(LoginResponseDTO.class);
-
         final LoginRequest loginRequest = mock(LoginRequest.class);
-        final LoginResponse loginResponse = mock(LoginResponse.class);
-
-        when(this.loginUser.execute(loginRequest)).thenReturn(loginResponse);
-        when(this.mapper.asLoginResponseDTO(loginResponse)).thenReturn(loginResponseDTO);
+        final SessionResponse sessionResponse = mock(SessionResponse.class);
+        final BffLoginSessionResult loginSessionResult = mock(BffLoginSessionResult.class);
 
         when(this.mapper.asLoginRequest(loginRequestDTO)).thenReturn(loginRequest);
+        when(this.loginUser.execute(loginRequest, "", "")).thenReturn(loginSessionResult);
+        when(loginSessionResult.getResponse()).thenReturn(sessionResponse);
+        when(loginSessionResult.getSessionId()).thenReturn("session-id");
+        when(loginSessionResult.getCsrfToken()).thenReturn("csrf-token");
+        when(this.sessionCookieManager.createSessionCookie("session-id")).thenReturn("session-cookie");
+        when(this.sessionCookieManager.createCsrfCookie("csrf-token")).thenReturn("csrf-cookie");
+        when(this.mapper.asLoginResponseDTO(sessionResponse)).thenReturn(loginResponseDTO);
 
         //when
         final ResponseEntity<LoginResponseDTO> actual = this.authController.login(loginRequestDTO);
 
         //then
-        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.OK).body(loginResponseDTO));
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(actual.getBody()).isEqualTo(loginResponseDTO);
+        assertThat(actual.getHeaders().get(HttpHeaders.SET_COOKIE)).containsExactly("session-cookie", "csrf-cookie");
 
         verify(this.mapper).asLoginRequest(loginRequestDTO);
-        verify(this.loginUser).execute(loginRequest);
-        verify(this.mapper).asLoginResponseDTO(loginResponse);
+        verify(this.loginUser).execute(loginRequest, "", "");
+        verify(loginSessionResult).getSessionId();
+        verify(loginSessionResult).getCsrfToken();
+        verify(loginSessionResult).getResponse();
+        verify(this.sessionCookieManager).createSessionCookie("session-id");
+        verify(this.sessionCookieManager).createCsrfCookie("csrf-token");
+        verify(this.mapper).asLoginResponseDTO(sessionResponse);
+    }
+
+    @Test
+    void givenValidSessionCookie_whenGetSession_thenReturnsResolvedSession() {
+        //given
+        final LoginResponseDTO loginResponseDTO = mock(LoginResponseDTO.class);
+        final BffResolvedSession resolvedSession = this.getResolvedSession();
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("__Host-admin_session", "session-id"));
+        request.addHeader(HttpHeaders.USER_AGENT, "Mozilla");
+        request.setRemoteAddr("10.0.0.5");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        when(this.sessionCookieManager.sessionCookieName()).thenReturn("__Host-admin_session");
+        when(this.getSession.execute("session-id", "Mozilla", "10.0.0.5"))
+                .thenReturn(Optional.of(resolvedSession));
+        when(this.sessionCookieManager.createCsrfCookie("csrf-token")).thenReturn("csrf-cookie");
+        when(this.mapper.asLoginResponseDTO(any(SessionResponse.class))).thenReturn(loginResponseDTO);
+        when(this.bffSessionProperties.getIdleTimeoutSeconds()).thenReturn(86_400L);
+
+        //when
+        final ResponseEntity<LoginResponseDTO> actual = this.authController.getSession();
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(actual.getBody()).isEqualTo(loginResponseDTO);
+        assertThat(actual.getHeaders().get(HttpHeaders.SET_COOKIE)).containsExactly("csrf-cookie");
+
+        verify(this.sessionCookieManager).sessionCookieName();
+        verify(this.getSession).execute("session-id", "Mozilla", "10.0.0.5");
+        verify(this.bffSessionProperties).getIdleTimeoutSeconds();
+        verify(this.sessionCookieManager).createCsrfCookie("csrf-token");
+        verify(this.mapper).asLoginResponseDTO(any(SessionResponse.class));
+    }
+
+    @Test
+    void givenNoResolvedSession_whenGetSession_thenReturnsUnauthorizedAndClearsCookies() {
+        //given
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("__Host-admin_session", "session-id"));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        when(this.sessionCookieManager.sessionCookieName()).thenReturn("__Host-admin_session");
+        when(this.getSession.execute("session-id", "", "127.0.0.1")).thenReturn(Optional.empty());
+        when(this.sessionCookieManager.clearSessionCookie()).thenReturn("clear-session-cookie");
+        when(this.sessionCookieManager.clearCsrfCookie()).thenReturn("clear-csrf-cookie");
+
+        //when
+        final ResponseEntity<LoginResponseDTO> actual = this.authController.getSession();
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(actual.getBody()).isEqualTo(new LoginResponseDTO().authenticated(Boolean.FALSE));
+        assertThat(actual.getHeaders().get(HttpHeaders.SET_COOKIE))
+                .containsExactly("clear-session-cookie", "clear-csrf-cookie");
+
+        verify(this.sessionCookieManager).sessionCookieName();
+        verify(this.getSession).execute("session-id", "", "127.0.0.1");
+        verify(this.sessionCookieManager).clearSessionCookie();
+        verify(this.sessionCookieManager).clearCsrfCookie();
     }
 
     @Test
@@ -185,5 +285,23 @@ class AuthControllerTest {
 
         verify(this.resendEmailVerification).execute();
         verify(this.resendEmailVerificationApiMapper).asResendEmailVerificationResponseDTO(response);
+    }
+
+    private BffResolvedSession getResolvedSession() {
+        return BffResolvedSession.builder()
+                .sessionId("session-id")
+                .session(this.getSessionData())
+                .build();
+    }
+
+    private BffSession getSessionData() {
+        return BffSession.builder()
+                .userId("user-id")
+                .email("user@sitionix.com")
+                .role("SUPER_ADMIN")
+                .siteId(UUID.fromString("0bf022f8-6f26-4ea8-ad6f-d8f93d32f60d"))
+                .csrfToken("csrf-token")
+                .maxExpiresAt(Instant.parse("2030-01-01T00:00:00Z"))
+                .build();
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/LoginUserApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/LoginUserApiMapperTest.java
@@ -2,13 +2,17 @@ package com.sitionix.bffssox.mapper;
 
 import com.app_afesox.bffssox.api_first.dto.LoginRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.LoginResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.SessionUserDTO;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
+import com.sitionix.bffssox.domain.SessionResponse;
+import com.sitionix.bffssox.domain.SessionUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,10 +42,10 @@ class LoginUserApiMapperTest {
     }
 
     @Test
-    void givenLoginResponse_whenAsLoginResponseDto_thenReturnLoginResponseDto() {
+    void givenSessionResponse_whenAsLoginResponseDto_thenReturnLoginResponseDto() {
         //given
         final LoginResponseDTO expected = this.loginResponseDTO();
-        final LoginResponse given = this.loginResponse();
+        final SessionResponse given = this.sessionResponse();
 
         //when
         final LoginResponseDTO actual = this.mapper.asLoginResponseDTO(given);
@@ -55,8 +59,6 @@ class LoginUserApiMapperTest {
                 .email("email")
                 .password("password")
                 .siteId(uuid)
-                .userAgent("userAgent")
-                .sessionSourceId("sessionSourceId")
                 .build();
     }
 
@@ -65,26 +67,34 @@ class LoginUserApiMapperTest {
                 .email("email")
                 .password("password")
                 .siteId(uuid)
-                .userAgent("userAgent")
-                .sessionSourceId("sessionSourceId")
                 .build();
     }
 
     private LoginResponseDTO loginResponseDTO() {
         return LoginResponseDTO.builder()
-                .refreshToken("refreshToken")
-                .expiresIn(3600L)
-                .tokenType("tokenType")
-                .accessToken("accessToken")
+                .authenticated(Boolean.TRUE)
+                .user(SessionUserDTO.builder()
+                        .id("123")
+                        .email("email@example.com")
+                        .role("SUPER_ADMIN")
+                        .siteId(UUID.fromString("261f6b83-f95f-4ab2-be1b-70f5c2ee7f54"))
+                        .build())
+                .expiresAt(OffsetDateTime.parse("2030-01-01T00:00:00Z"))
+                .idleTimeoutSeconds(86_400L)
                 .build();
     }
 
-    private LoginResponse loginResponse() {
-        return LoginResponse.builder()
-                .refreshToken("refreshToken")
-                .expiresIn(3600L)
-                .tokenType("tokenType")
-                .accessToken("accessToken")
+    private SessionResponse sessionResponse() {
+        return SessionResponse.builder()
+                .authenticated(Boolean.TRUE)
+                .user(SessionUser.builder()
+                        .id("123")
+                        .email("email@example.com")
+                        .role("SUPER_ADMIN")
+                        .siteId(UUID.fromString("261f6b83-f95f-4ab2-be1b-70f5c2ee7f54"))
+                        .build())
+                .expiresAt(Instant.parse("2030-01-01T00:00:00Z"))
+                .idleTimeoutSeconds(86_400L)
                 .build();
     }
 }

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>spring-boot</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/application/src/main/java/com/sitionix/bffssox/session/BffSessionManagerImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/session/BffSessionManagerImpl.java
@@ -1,0 +1,302 @@
+package com.sitionix.bffssox.session;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sitionix.bffssox.client.AuthUserClient;
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSession;
+import com.sitionix.bffssox.domain.BffSessionException;
+import com.sitionix.bffssox.domain.BffSessionManager;
+import com.sitionix.bffssox.domain.BffSessionProperties;
+import com.sitionix.bffssox.domain.BffSessionStore;
+import com.sitionix.bffssox.domain.ClientResponseException;
+import com.sitionix.bffssox.domain.LoginRequest;
+import com.sitionix.bffssox.domain.LoginResponse;
+import com.sitionix.bffssox.domain.RefreshAccessTokenRequest;
+import com.sitionix.bffssox.domain.RefreshAccessTokenResponse;
+import com.sitionix.bffssox.domain.SessionResponse;
+import com.sitionix.bffssox.domain.SessionUser;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Service
+public class BffSessionManagerImpl implements BffSessionManager {
+
+    private final AuthUserClient authUserClient;
+
+    private final BffSessionStore bffSessionStore;
+
+    private final BffSessionProperties bffSessionProperties;
+
+    private final SessionIdGenerator sessionIdGenerator;
+
+    private final ObjectMapper objectMapper;
+
+    private final Clock clock;
+
+    private final ConcurrentMap<String, ReentrantLock> refreshLocks = new ConcurrentHashMap<>();
+
+    public BffSessionManagerImpl(final AuthUserClient authUserClient,
+                                 final BffSessionStore bffSessionStore,
+                                 final BffSessionProperties bffSessionProperties,
+                                 final SessionIdGenerator sessionIdGenerator,
+                                 final ObjectMapper objectMapper,
+                                 final Clock clock) {
+        this.authUserClient = authUserClient;
+        this.bffSessionStore = bffSessionStore;
+        this.bffSessionProperties = bffSessionProperties;
+        this.sessionIdGenerator = sessionIdGenerator;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    @Override
+    public BffLoginSessionResult createSession(final LoginRequest request, final String userAgent, final String remoteAddress) {
+        final String authSessionSourceId = UUID.randomUUID().toString();
+        final LoginRequest authLoginRequest = LoginRequest.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .siteId(request.getSiteId())
+                .sessionSourceId(authSessionSourceId)
+                .userAgent(userAgent)
+                .build();
+        final com.sitionix.bffssox.domain.LoginResponse authLoginResponse = this.authUserClient.login(authLoginRequest);
+        final Instant now = this.clock.instant();
+        final TokenClaims claims = this.parseClaims(authLoginResponse.getAccessToken());
+        final BffSession session = BffSession.builder()
+                .userId(claims.userId())
+                .email(claims.email())
+                .role(claims.role())
+                .siteId(claims.siteId())
+                .authSessionSourceId(authSessionSourceId)
+                .accessToken(authLoginResponse.getAccessToken())
+                .accessTokenExpiresAt(claims.expiresAt())
+                .refreshToken(authLoginResponse.getRefreshToken())
+                .refreshTokenExpiresAt(now.plusSeconds(this.bffSessionProperties.getAbsoluteTimeoutSeconds()))
+                .csrfToken(this.sessionIdGenerator.newCsrfToken())
+                .createdAt(now)
+                .lastUsedAt(now)
+                .lastRotatedAt(now)
+                .maxExpiresAt(now.plusSeconds(this.bffSessionProperties.getAbsoluteTimeoutSeconds()))
+                .build();
+        final String sessionId = this.bffSessionStore.create(session);
+        return BffLoginSessionResult.builder()
+                .sessionId(sessionId)
+                .csrfToken(session.getCsrfToken())
+                .response(this.toLoginResponse(session))
+                .build();
+    }
+
+    @Override
+    public Optional<BffResolvedSession> resolveSession(final String sessionId, final String userAgent, final String remoteAddress) {
+        if (sessionId == null || sessionId.isBlank()) {
+            return Optional.empty();
+        }
+        final Optional<BffSession> sessionOptional = this.bffSessionStore.get(sessionId);
+        if (sessionOptional.isEmpty()) {
+            return Optional.empty();
+        }
+        final Instant now = this.clock.instant();
+        final BffSession session = sessionOptional.get();
+        if (this.isInvalid(session, now)) {
+            this.invalidateSession(sessionId);
+            return Optional.empty();
+        }
+        final Optional<BffResolvedSession> refreshedSession = this.refreshSession(sessionId, false);
+        if (refreshedSession.isEmpty()) {
+            return Optional.empty();
+        }
+        BffResolvedSession resolvedSession = refreshedSession.get();
+        if (this.shouldRotate(resolvedSession.getSession(), now)) {
+            final String newSessionId = this.bffSessionStore.rotate(resolvedSession.getSessionId(), now);
+            final Optional<BffSession> rotatedSession = this.bffSessionStore.get(newSessionId);
+            if (rotatedSession.isEmpty()) {
+                return Optional.empty();
+            }
+            resolvedSession = BffResolvedSession.builder()
+                    .previousSessionId(resolvedSession.getSessionId())
+                    .sessionId(newSessionId)
+                    .session(rotatedSession.get())
+                    .build();
+        }
+        if (this.shouldTouch(resolvedSession.getSession(), now)) {
+            this.bffSessionStore.touch(resolvedSession.getSessionId(), now);
+            final BffSession touchedSession = resolvedSession.getSession().toBuilder()
+                    .lastUsedAt(now)
+                    .build();
+            this.bffSessionStore.update(resolvedSession.getSessionId(), touchedSession);
+            resolvedSession = BffResolvedSession.builder()
+                    .previousSessionId(resolvedSession.getPreviousSessionId())
+                    .sessionId(resolvedSession.getSessionId())
+                    .session(touchedSession)
+                    .build();
+        }
+        return Optional.of(resolvedSession);
+    }
+
+    @Override
+    public Optional<BffResolvedSession> refreshSession(final String sessionId, final boolean forceRefresh) {
+        if (sessionId == null || sessionId.isBlank()) {
+            return Optional.empty();
+        }
+        final Optional<BffSession> existingSession = this.bffSessionStore.get(sessionId);
+        if (existingSession.isEmpty()) {
+            return Optional.empty();
+        }
+        if (!forceRefresh && !this.shouldRefresh(existingSession.get(), this.clock.instant())) {
+            return Optional.of(BffResolvedSession.builder()
+                    .sessionId(sessionId)
+                    .session(existingSession.get())
+                    .build());
+        }
+        final ReentrantLock lock = this.refreshLocks.computeIfAbsent(sessionId, key -> new ReentrantLock());
+        lock.lock();
+        try {
+            final Optional<BffSession> lockedSession = this.bffSessionStore.get(sessionId);
+            if (lockedSession.isEmpty()) {
+                return Optional.empty();
+            }
+            final Instant now = this.clock.instant();
+            final BffSession session = lockedSession.get();
+            if (this.isInvalid(session, now)) {
+                this.invalidateSession(sessionId);
+                return Optional.empty();
+            }
+            if (!forceRefresh && !this.shouldRefresh(session, now)) {
+                return Optional.of(BffResolvedSession.builder()
+                        .sessionId(sessionId)
+                        .session(session)
+                        .build());
+            }
+            final RefreshAccessTokenResponse refreshResponse;
+            try {
+                refreshResponse = this.refreshTokens(session);
+            } catch (ClientResponseException ex) {
+                final int status = ex.getStatusCode();
+                if (status == 401 || status == 403) {
+                    this.invalidateSession(sessionId);
+                    return Optional.empty();
+                }
+                throw ex;
+            }
+            final TokenClaims claims = this.parseClaims(refreshResponse.getAccessToken());
+            final BffSession updatedSession = session.toBuilder()
+                    .accessToken(refreshResponse.getAccessToken())
+                    .accessTokenExpiresAt(claims.expiresAt())
+                    .refreshToken(refreshResponse.getRefreshToken())
+                    .build();
+            this.bffSessionStore.update(sessionId, updatedSession);
+            return Optional.of(BffResolvedSession.builder()
+                    .sessionId(sessionId)
+                    .session(updatedSession)
+                    .build());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void invalidateSession(final String sessionId) {
+        if (sessionId == null || sessionId.isBlank()) {
+            return;
+        }
+        this.bffSessionStore.delete(sessionId);
+    }
+
+    private RefreshAccessTokenResponse refreshTokens(final BffSession session) {
+        return this.authUserClient.refreshAccessToken(RefreshAccessTokenRequest.builder()
+                .refreshToken(session.getRefreshToken())
+                .sessionSourceId(session.getAuthSessionSourceId())
+                .build());
+    }
+
+    private SessionResponse toLoginResponse(final BffSession session) {
+        return SessionResponse.builder()
+                .authenticated(Boolean.TRUE)
+                .user(SessionUser.builder()
+                        .id(session.getUserId())
+                        .email(session.getEmail())
+                        .role(session.getRole())
+                        .siteId(session.getSiteId())
+                        .build())
+                .expiresAt(session.getMaxExpiresAt())
+                .idleTimeoutSeconds(this.bffSessionProperties.getIdleTimeoutSeconds())
+                .build();
+    }
+
+    private boolean shouldRefresh(final BffSession session, final Instant now) {
+        final Instant accessTokenExpiresAt = session.getAccessTokenExpiresAt();
+        if (accessTokenExpiresAt == null) {
+            return true;
+        }
+        return !accessTokenExpiresAt.isAfter(now.plusSeconds(this.bffSessionProperties.getRefreshSkewSeconds()));
+    }
+
+    private boolean shouldTouch(final BffSession session, final Instant now) {
+        final Instant lastUsedAt = session.getLastUsedAt();
+        if (lastUsedAt == null) {
+            return true;
+        }
+        return !lastUsedAt.isAfter(now.minusSeconds(this.bffSessionProperties.getTouchThrottleSeconds()));
+    }
+
+    private boolean shouldRotate(final BffSession session, final Instant now) {
+        final Instant lastRotatedAt = session.getLastRotatedAt();
+        if (lastRotatedAt == null) {
+            return true;
+        }
+        return !lastRotatedAt.isAfter(now.minusSeconds(this.bffSessionProperties.getRotationIntervalSeconds()));
+    }
+
+    private boolean isInvalid(final BffSession session, final Instant now) {
+        if (session.getLastUsedAt() == null || session.getMaxExpiresAt() == null) {
+            return true;
+        }
+        final Instant idleExpiry = session.getLastUsedAt().plusSeconds(this.bffSessionProperties.getIdleTimeoutSeconds());
+        if (!idleExpiry.isAfter(now)) {
+            return true;
+        }
+        return !session.getMaxExpiresAt().isAfter(now);
+    }
+
+    private TokenClaims parseClaims(final String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new BffSessionException("Access token is empty");
+        }
+        try {
+            final String[] parts = accessToken.split("\\.");
+            if (parts.length < 2) {
+                throw new BffSessionException("Access token has invalid JWT format");
+            }
+            final byte[] payload = Base64.getUrlDecoder().decode(parts[1]);
+            final JsonNode claims = this.objectMapper.readTree(new String(payload, StandardCharsets.UTF_8));
+            final String userId = claims.path("sub").asText(null);
+            final String email = claims.path("email").asText(null);
+            final String role = claims.path("role").asText(null);
+            final String siteIdRaw = claims.path("siteId").asText(null);
+            final long exp = claims.path("exp").asLong(0L);
+            if (userId == null || email == null || role == null || exp <= 0L) {
+                throw new BffSessionException("Access token misses required claims");
+            }
+            final UUID siteId = siteIdRaw == null || siteIdRaw.isBlank() ? null : UUID.fromString(siteIdRaw);
+            return new TokenClaims(userId, email, role, siteId, Instant.ofEpochSecond(exp));
+        } catch (BffSessionException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new BffSessionException("Unable to parse access token claims");
+        }
+    }
+
+    private record TokenClaims(String userId, String email, String role, UUID siteId, Instant expiresAt) {
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/session/InMemoryBffSessionStore.java
+++ b/application/src/main/java/com/sitionix/bffssox/session/InMemoryBffSessionStore.java
@@ -1,0 +1,65 @@
+package com.sitionix.bffssox.session;
+
+import com.sitionix.bffssox.domain.BffSession;
+import com.sitionix.bffssox.domain.BffSessionException;
+import com.sitionix.bffssox.domain.BffSessionStore;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class InMemoryBffSessionStore implements BffSessionStore {
+
+    private final ConcurrentMap<String, BffSession> sessions = new ConcurrentHashMap<>();
+
+    private final SessionIdGenerator sessionIdGenerator;
+
+    public InMemoryBffSessionStore(final SessionIdGenerator sessionIdGenerator) {
+        this.sessionIdGenerator = sessionIdGenerator;
+    }
+
+    @Override
+    public String create(final BffSession session) {
+        final String sessionId = this.sessionIdGenerator.newSessionId();
+        this.sessions.put(sessionId, session);
+        return sessionId;
+    }
+
+    @Override
+    public Optional<BffSession> get(final String sessionId) {
+        return Optional.ofNullable(this.sessions.get(sessionId));
+    }
+
+    @Override
+    public void update(final String sessionId, final BffSession session) {
+        this.sessions.put(sessionId, session);
+    }
+
+    @Override
+    public void touch(final String sessionId, final Instant now) {
+        this.sessions.computeIfPresent(sessionId, (key, session) -> session.toBuilder()
+                .lastUsedAt(now)
+                .build());
+    }
+
+    @Override
+    public String rotate(final String sessionId, final Instant now) {
+        final BffSession current = this.sessions.remove(sessionId);
+        if (current == null) {
+            throw new BffSessionException("Session is not found for rotation");
+        }
+        final String newSessionId = this.sessionIdGenerator.newSessionId();
+        this.sessions.put(newSessionId, current.toBuilder()
+                .lastRotatedAt(now)
+                .build());
+        return newSessionId;
+    }
+
+    @Override
+    public void delete(final String sessionId) {
+        this.sessions.remove(sessionId);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/session/SessionIdGenerator.java
+++ b/application/src/main/java/com/sitionix/bffssox/session/SessionIdGenerator.java
@@ -1,0 +1,30 @@
+package com.sitionix.bffssox.session;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class SessionIdGenerator {
+
+    private static final int SESSION_ID_BYTES = 32;
+
+    private static final int CSRF_TOKEN_BYTES = 24;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String newSessionId() {
+        return this.generate(SESSION_ID_BYTES);
+    }
+
+    public String newCsrfToken() {
+        return this.generate(CSRF_TOKEN_BYTES);
+    }
+
+    private String generate(final int byteSize) {
+        final byte[] bytes = new byte[byteSize];
+        this.secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/GetSessionImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/GetSessionImpl.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSessionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GetSessionImpl implements GetSession {
+
+    private final BffSessionManager bffSessionManager;
+
+    @Override
+    public Optional<BffResolvedSession> execute(final String sessionId, final String userAgent, final String remoteAddress) {
+        return this.bffSessionManager.resolveSession(sessionId, userAgent, remoteAddress);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/LoginUserImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/LoginUserImpl.java
@@ -1,19 +1,19 @@
 package com.sitionix.bffssox.usecase;
 
-import com.sitionix.bffssox.client.AuthUserClient;
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
+import com.sitionix.bffssox.domain.BffSessionManager;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class LoginUserImpl implements LoginUser{
+public class LoginUserImpl implements LoginUser {
 
-    private final AuthUserClient authUserClient;
+    private final BffSessionManager bffSessionManager;
 
     @Override
-    public LoginResponse execute(final LoginRequest request) {
-        return this.authUserClient.login(request);
+    public BffLoginSessionResult execute(final LoginRequest request, final String userAgent, final String remoteAddress) {
+        return this.bffSessionManager.createSession(request, userAgent, remoteAddress);
     }
 }

--- a/application/src/test/java/com/sitionix/bffssox/session/BffSessionManagerImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/session/BffSessionManagerImplTest.java
@@ -1,0 +1,307 @@
+package com.sitionix.bffssox.session;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sitionix.bffssox.client.AuthUserClient;
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSession;
+import com.sitionix.bffssox.domain.BffSessionProperties;
+import com.sitionix.bffssox.domain.BffSessionStore;
+import com.sitionix.bffssox.domain.ClientResponseException;
+import com.sitionix.bffssox.domain.LoginRequest;
+import com.sitionix.bffssox.domain.LoginResponse;
+import com.sitionix.bffssox.domain.RefreshAccessTokenRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BffSessionManagerImplTest {
+
+    private BffSessionManagerImpl bffSessionManager;
+
+    @Mock
+    private AuthUserClient authUserClient;
+
+    @Mock
+    private BffSessionStore bffSessionStore;
+
+    @Mock
+    private BffSessionProperties bffSessionProperties;
+
+    @Mock
+    private SessionIdGenerator sessionIdGenerator;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        this.bffSessionManager = new BffSessionManagerImpl(
+                this.authUserClient,
+                this.bffSessionStore,
+                this.bffSessionProperties,
+                this.sessionIdGenerator,
+                this.objectMapper,
+                this.clock
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(
+                this.authUserClient,
+                this.bffSessionStore,
+                this.bffSessionProperties,
+                this.sessionIdGenerator,
+                this.objectMapper,
+                this.clock
+        );
+    }
+
+    @Test
+    void givenValidLoginRequest_whenCreateSession_thenPersistSessionAndReturnSessionResponse() throws Exception {
+        //given
+        final Instant now = Instant.parse("2026-02-23T12:00:00Z");
+        final UUID siteId = UUID.fromString("99970811-be3e-4a15-917b-e921f4069fba");
+        final String claimsPayload = this.getClaimsPayload(1_772_153_200L, siteId);
+        final String accessToken = this.getJwt(claimsPayload);
+        final JsonNode claimsNode = this.readJson(claimsPayload);
+        final LoginRequest request = this.getLoginRequest(siteId);
+
+        when(this.clock.instant()).thenReturn(now);
+        when(this.bffSessionProperties.getAbsoluteTimeoutSeconds()).thenReturn(1_200L);
+        when(this.bffSessionProperties.getIdleTimeoutSeconds()).thenReturn(86_400L);
+        when(this.authUserClient.login(any(LoginRequest.class))).thenReturn(LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken("refresh-token")
+                .build());
+        when(this.objectMapper.readTree(claimsPayload)).thenReturn(claimsNode);
+        when(this.sessionIdGenerator.newCsrfToken()).thenReturn("csrf-token");
+        when(this.bffSessionStore.create(any(BffSession.class))).thenReturn("session-id");
+
+        //when
+        final BffLoginSessionResult actual = this.bffSessionManager.createSession(request, "Mozilla", "10.0.0.5");
+
+        //then
+        assertThat(actual.getSessionId()).isEqualTo("session-id");
+        assertThat(actual.getCsrfToken()).isEqualTo("csrf-token");
+        assertThat(actual.getResponse().getAuthenticated()).isEqualTo(Boolean.TRUE);
+        assertThat(actual.getResponse().getUser().getId()).isEqualTo("user-1");
+        assertThat(actual.getResponse().getUser().getEmail()).isEqualTo("user@sitionix.com");
+        assertThat(actual.getResponse().getUser().getRole()).isEqualTo("SUPER_ADMIN");
+        assertThat(actual.getResponse().getUser().getSiteId()).isEqualTo(siteId);
+        assertThat(actual.getResponse().getIdleTimeoutSeconds()).isEqualTo(86_400L);
+        assertThat(actual.getResponse().getExpiresAt()).isEqualTo(now.plusSeconds(1_200L));
+
+        final ArgumentCaptor<LoginRequest> loginRequestCaptor = ArgumentCaptor.forClass(LoginRequest.class);
+        verify(this.authUserClient).login(loginRequestCaptor.capture());
+        final LoginRequest authLoginRequest = loginRequestCaptor.getValue();
+        assertThat(authLoginRequest.getEmail()).isEqualTo("user@sitionix.com");
+        assertThat(authLoginRequest.getPassword()).isEqualTo("password");
+        assertThat(authLoginRequest.getSiteId()).isEqualTo(siteId);
+        assertThat(authLoginRequest.getUserAgent()).isEqualTo("Mozilla");
+        assertThat(authLoginRequest.getSessionSourceId()).isNotBlank();
+
+        final ArgumentCaptor<BffSession> sessionCaptor = ArgumentCaptor.forClass(BffSession.class);
+        verify(this.bffSessionStore).create(sessionCaptor.capture());
+        final BffSession persistedSession = sessionCaptor.getValue();
+        assertThat(persistedSession.getAuthSessionSourceId()).isEqualTo(authLoginRequest.getSessionSourceId());
+        assertThat(persistedSession.getAccessToken()).isEqualTo(accessToken);
+        assertThat(persistedSession.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(persistedSession.getCsrfToken()).isEqualTo("csrf-token");
+
+        verify(this.objectMapper).readTree(claimsPayload);
+        verify(this.clock).instant();
+        verify(this.sessionIdGenerator).newCsrfToken();
+        verify(this.bffSessionProperties, times(2)).getAbsoluteTimeoutSeconds();
+        verify(this.bffSessionProperties).getIdleTimeoutSeconds();
+    }
+
+    @Test
+    void givenIdleExpiredSession_whenResolveSession_thenInvalidateAndReturnEmpty() {
+        //given
+        final Instant now = Instant.parse("2026-02-23T12:00:00Z");
+        final BffSession session = this.getSession(
+                now.minusSeconds(120L),
+                now.minusSeconds(360L),
+                now.plusSeconds(600L),
+                now.plusSeconds(600L)
+        );
+
+        when(this.bffSessionStore.get("session-id")).thenReturn(Optional.of(session));
+        when(this.bffSessionProperties.getIdleTimeoutSeconds()).thenReturn(60L);
+        when(this.clock.instant()).thenReturn(now);
+
+        //when
+        final Optional<BffResolvedSession> actual = this.bffSessionManager.resolveSession("session-id", "Mozilla", "10.0.0.5");
+
+        //then
+        assertThat(actual).isEmpty();
+
+        verify(this.bffSessionStore).get("session-id");
+        verify(this.bffSessionStore).delete("session-id");
+        verify(this.bffSessionProperties).getIdleTimeoutSeconds();
+        verify(this.clock).instant();
+    }
+
+    @Test
+    void givenSessionRequiresRotationAndTouch_whenResolveSession_thenRotateAndTouchSession() {
+        //given
+        final Instant now = Instant.parse("2026-02-23T12:00:00Z");
+        final BffSession session = this.getSession(
+                now.minusSeconds(120L),
+                now.minusSeconds(500L),
+                now.plusSeconds(600L),
+                now.plusSeconds(600L)
+        );
+        final BffSession rotatedSession = session.toBuilder()
+                .lastRotatedAt(now)
+                .build();
+
+        when(this.bffSessionStore.get("session-id"))
+                .thenReturn(Optional.of(session), Optional.of(session));
+        when(this.bffSessionStore.rotate("session-id", now)).thenReturn("session-id-2");
+        when(this.bffSessionStore.get("session-id-2")).thenReturn(Optional.of(rotatedSession));
+        when(this.bffSessionProperties.getIdleTimeoutSeconds()).thenReturn(300L);
+        when(this.bffSessionProperties.getRefreshSkewSeconds()).thenReturn(60L);
+        when(this.bffSessionProperties.getRotationIntervalSeconds()).thenReturn(300L);
+        when(this.bffSessionProperties.getTouchThrottleSeconds()).thenReturn(30L);
+        when(this.clock.instant()).thenReturn(now, now);
+
+        //when
+        final Optional<BffResolvedSession> actual = this.bffSessionManager.resolveSession("session-id", "Mozilla", "10.0.0.5");
+
+        //then
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getSessionId()).isEqualTo("session-id-2");
+        assertThat(actual.get().getPreviousSessionId()).isEqualTo("session-id");
+        assertThat(actual.get().getSession().getLastUsedAt()).isEqualTo(now);
+
+        verify(this.bffSessionStore, times(2)).get("session-id");
+        verify(this.bffSessionStore).rotate("session-id", now);
+        verify(this.bffSessionStore).get("session-id-2");
+        verify(this.bffSessionStore).touch("session-id-2", now);
+
+        final ArgumentCaptor<BffSession> updatedSessionCaptor = ArgumentCaptor.forClass(BffSession.class);
+        verify(this.bffSessionStore).update(eq("session-id-2"), updatedSessionCaptor.capture());
+        assertThat(updatedSessionCaptor.getValue().getLastUsedAt()).isEqualTo(now);
+
+        verify(this.bffSessionProperties).getIdleTimeoutSeconds();
+        verify(this.bffSessionProperties).getRefreshSkewSeconds();
+        verify(this.bffSessionProperties).getRotationIntervalSeconds();
+        verify(this.bffSessionProperties).getTouchThrottleSeconds();
+        verify(this.clock, times(2)).instant();
+    }
+
+    @Test
+    void givenRefreshUnauthorized_whenRefreshSession_thenInvalidateAndReturnEmpty() {
+        //given
+        final Instant now = Instant.parse("2026-02-23T12:00:00Z");
+        final BffSession session = this.getSession(
+                now.minusSeconds(10L),
+                now.minusSeconds(10L),
+                now.plusSeconds(15L),
+                now.plusSeconds(600L)
+        );
+
+        when(this.bffSessionStore.get("session-id"))
+                .thenReturn(Optional.of(session), Optional.of(session));
+        when(this.bffSessionProperties.getRefreshSkewSeconds()).thenReturn(60L);
+        when(this.bffSessionProperties.getIdleTimeoutSeconds()).thenReturn(300L);
+        when(this.clock.instant()).thenReturn(now, now);
+        when(this.authUserClient.refreshAccessToken(any(RefreshAccessTokenRequest.class)))
+                .thenThrow(new ClientResponseException(
+                        401,
+                        "{\"error\":\"unauthorized\"}",
+                        Collections.emptyMap(),
+                        null
+                ));
+
+        //when
+        final Optional<BffResolvedSession> actual = this.bffSessionManager.refreshSession("session-id", false);
+
+        //then
+        assertThat(actual).isEmpty();
+
+        final ArgumentCaptor<RefreshAccessTokenRequest> requestCaptor = ArgumentCaptor.forClass(RefreshAccessTokenRequest.class);
+        verify(this.authUserClient).refreshAccessToken(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(requestCaptor.getValue().getSessionSourceId()).isEqualTo("source-id");
+
+        verify(this.bffSessionStore, times(2)).get("session-id");
+        verify(this.bffSessionStore).delete("session-id");
+        verify(this.bffSessionProperties, times(2)).getRefreshSkewSeconds();
+        verify(this.bffSessionProperties).getIdleTimeoutSeconds();
+        verify(this.clock, times(2)).instant();
+    }
+
+    private LoginRequest getLoginRequest(final UUID siteId) {
+        return LoginRequest.builder()
+                .email("user@sitionix.com")
+                .password("password")
+                .siteId(siteId)
+                .build();
+    }
+
+    private BffSession getSession(final Instant lastUsedAt,
+                                  final Instant lastRotatedAt,
+                                  final Instant accessTokenExpiresAt,
+                                  final Instant maxExpiresAt) {
+        return BffSession.builder()
+                .userId("user-1")
+                .email("user@sitionix.com")
+                .role("SUPER_ADMIN")
+                .siteId(UUID.fromString("99970811-be3e-4a15-917b-e921f4069fba"))
+                .authSessionSourceId("source-id")
+                .accessToken("access-token")
+                .accessTokenExpiresAt(accessTokenExpiresAt)
+                .refreshToken("refresh-token")
+                .csrfToken("csrf-token")
+                .createdAt(lastUsedAt)
+                .lastUsedAt(lastUsedAt)
+                .lastRotatedAt(lastRotatedAt)
+                .maxExpiresAt(maxExpiresAt)
+                .build();
+    }
+
+    private String getClaimsPayload(final long exp, final UUID siteId) {
+        return "{\"sub\":\"user-1\",\"email\":\"user@sitionix.com\",\"role\":\"SUPER_ADMIN\",\"siteId\":\""
+                + siteId + "\",\"exp\":" + exp + "}";
+    }
+
+    private String getJwt(final String payload) {
+        final String encodedPayload = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        return "header." + encodedPayload + ".signature";
+    }
+
+    private JsonNode readJson(final String payload) throws Exception {
+        return new ObjectMapper().readTree(payload);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/LoginUserImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/LoginUserImplTest.java
@@ -1,8 +1,8 @@
 package com.sitionix.bffssox.usecase;
 
-import com.sitionix.bffssox.client.AuthUserClient;
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
+import com.sitionix.bffssox.domain.BffSessionManager;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,33 +19,33 @@ class LoginUserImplTest {
     private LoginUser loginUser;
 
     @Mock
-    private AuthUserClient authUserClient;
+    private BffSessionManager bffSessionManager;
 
     @BeforeEach
     void setUp() {
-        loginUser = new LoginUserImpl(this.authUserClient);
+        this.loginUser = new LoginUserImpl(this.bffSessionManager);
     }
 
     @AfterEach
     void tearDown() {
-        verifyNoMoreInteractions(this.authUserClient);
+        verifyNoMoreInteractions(this.bffSessionManager);
     }
 
     @Test
-    void givenLoginRequest_whenExecute_thenReturnLoginResponse() {
-        // given
+    void givenLoginRequest_whenExecute_thenReturnLoginSessionResult() {
+        //given
         final LoginRequest loginRequest = mock(LoginRequest.class);
-        final LoginResponse loginResponse = mock(LoginResponse.class);
+        final BffLoginSessionResult loginSessionResult = mock(BffLoginSessionResult.class);
 
-        when(this.authUserClient.login(loginRequest)).thenReturn(loginResponse);
+        when(this.bffSessionManager.createSession(loginRequest, "Mozilla", "10.0.0.5"))
+                .thenReturn(loginSessionResult);
 
-        // when
-        final LoginResponse actual = this.loginUser.execute(loginRequest);
+        //when
+        final BffLoginSessionResult actual = this.loginUser.execute(loginRequest, "Mozilla", "10.0.0.5");
 
-        // then
-        assertThat(actual).isEqualTo(loginResponse);
+        //then
+        assertThat(actual).isEqualTo(loginSessionResult);
 
-        verify(this.authUserClient).login(loginRequest);
-
+        verify(this.bffSessionManager).createSession(loginRequest, "Mozilla", "10.0.0.5");
     }
 }

--- a/boot/src/main/java/com/sitionix/bffssox/config/AthssoxApiConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/AthssoxApiConfig.java
@@ -3,6 +3,7 @@ package com.sitionix.bffssox.config;
 import com.app_afesox.athssox.client.api.AuthApi;
 import com.app_afesox.athssox.client.api.UserApi;
 import com.app_afesox.athssox.client.invoker.ApiClient;
+import com.sitionix.bffssox.security.BffUserTokenPropagationInterceptor;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -34,10 +35,12 @@ public class AthssoxApiConfig {
     }
 
     @Bean("athssoxRestTemplate")
-    public RestTemplate athssoxRestTemplate() {
+    public RestTemplate athssoxRestTemplate(final BffUserTokenPropagationInterceptor bffUserTokenPropagationInterceptor) {
         final HttpComponentsClientHttpRequestFactory requestFactory =
                 new HttpComponentsClientHttpRequestFactory(HttpClients.createDefault());
-        return new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        final RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        restTemplate.getInterceptors().add(0, bffUserTokenPropagationInterceptor);
+        return restTemplate;
     }
 
     @Bean

--- a/boot/src/main/java/com/sitionix/bffssox/config/ClockConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.sitionix.bffssox.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/boot/src/main/java/com/sitionix/bffssox/config/CorsConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/CorsConfig.java
@@ -24,7 +24,7 @@ public class CorsConfig implements WebMvcConfigurer {
                         HttpMethod.DELETE.name(),
                         HttpMethod.OPTIONS.name()
                 )
-                .allowedHeaders("Content-Type", "Authorization")
+                .allowedHeaders("Content-Type", "Authorization", "X-CSRF")
                 .allowCredentials(true);
     }
 }

--- a/boot/src/main/java/com/sitionix/bffssox/config/SecurityConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.sitionix.bffssox.config;
+
+import com.sitionix.bffssox.security.BffCsrfFilter;
+import com.sitionix.bffssox.security.BffSessionAuthenticationFilter;
+import com.sitionix.forge.security.userjwt.web.ForgeUserJwtFilter;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http,
+                                                   final ObjectProvider<ForgeUserJwtFilter> forgeUserJwtFilterProvider,
+                                                   final BffSessionAuthenticationFilter bffSessionAuthenticationFilter,
+                                                   final BffCsrfFilter bffCsrfFilter,
+                                                   final ObjectProvider<AuthenticationEntryPoint> entryPointProvider,
+                                                   final ObjectProvider<AccessDeniedHandler> accessDeniedHandlerProvider)
+            throws Exception {
+        final ForgeUserJwtFilter forgeUserJwtFilter = forgeUserJwtFilterProvider.getIfAvailable();
+        final AuthenticationEntryPoint entryPoint = entryPointProvider.getIfAvailable();
+        final AccessDeniedHandler accessDeniedHandler = accessDeniedHandlerProvider.getIfAvailable();
+        http.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+        if (forgeUserJwtFilter != null) {
+            http.addFilterBefore(forgeUserJwtFilter, AuthorizationFilter.class)
+                    .addFilterAfter(bffSessionAuthenticationFilter, ForgeUserJwtFilter.class);
+        } else {
+            http.addFilterBefore(bffSessionAuthenticationFilter, AuthorizationFilter.class);
+        }
+        http.addFilterAfter(bffCsrfFilter, BffSessionAuthenticationFilter.class);
+        if (entryPoint != null || accessDeniedHandler != null) {
+            http.exceptionHandling(exceptionHandling -> {
+                if (entryPoint != null) {
+                    exceptionHandling.authenticationEntryPoint(entryPoint);
+                }
+                if (accessDeniedHandler != null) {
+                    exceptionHandling.accessDeniedHandler(accessDeniedHandler);
+                }
+            });
+        }
+        return http.build();
+    }
+}

--- a/boot/src/main/java/com/sitionix/bffssox/config/StsssoxApiConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/StsssoxApiConfig.java
@@ -2,6 +2,7 @@ package com.sitionix.bffssox.config;
 
 import com.app_afesox.stsssox.client.api.SiteApi;
 import com.app_afesox.stsssox.client.invoker.ApiClient;
+import com.sitionix.bffssox.security.BffUserTokenPropagationInterceptor;
 import lombok.Data;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,10 +34,12 @@ public class StsssoxApiConfig {
     }
 
     @Bean("stsssoxRestTemplate")
-    public RestTemplate stsssoxRestTemplate() {
+    public RestTemplate stsssoxRestTemplate(final BffUserTokenPropagationInterceptor bffUserTokenPropagationInterceptor) {
         final HttpComponentsClientHttpRequestFactory requestFactory =
                 new HttpComponentsClientHttpRequestFactory(HttpClients.createDefault());
-        return new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        final RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        restTemplate.getInterceptors().add(0, bffUserTokenPropagationInterceptor);
+        return restTemplate;
     }
 
     @Bean

--- a/boot/src/main/java/com/sitionix/bffssox/config/WagssoxApiConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/WagssoxApiConfig.java
@@ -2,6 +2,7 @@ package com.sitionix.bffssox.config;
 
 import com.app_afesox.wagssox.client.api.SiteApi;
 import com.app_afesox.wagssox.client.invoker.ApiClient;
+import com.sitionix.bffssox.security.BffUserTokenPropagationInterceptor;
 import lombok.Data;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,10 +34,12 @@ public class WagssoxApiConfig {
     }
 
     @Bean("wagssoxRestTemplate")
-    public RestTemplate wagssoxRestTemplate() {
+    public RestTemplate wagssoxRestTemplate(final BffUserTokenPropagationInterceptor bffUserTokenPropagationInterceptor) {
         final HttpComponentsClientHttpRequestFactory requestFactory =
                 new HttpComponentsClientHttpRequestFactory(HttpClients.createDefault());
-        return new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        final RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(requestFactory));
+        restTemplate.getInterceptors().add(0, bffUserTokenPropagationInterceptor);
+        return restTemplate;
     }
 
     @Bean

--- a/boot/src/main/java/com/sitionix/bffssox/security/BffCsrfFilter.java
+++ b/boot/src/main/java/com/sitionix/bffssox/security/BffCsrfFilter.java
@@ -1,0 +1,111 @@
+package com.sitionix.bffssox.security;
+
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import com.sitionix.bffssox.domain.BffSessionProperties;
+import com.sitionix.bffssox.domain.SessionCookieManager;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class BffCsrfFilter extends OncePerRequestFilter {
+
+    private final BffSessionProperties bffSessionProperties;
+
+    private final SessionCookieManager sessionCookieManager;
+
+    public BffCsrfFilter(final BffSessionProperties bffSessionProperties,
+                         final SessionCookieManager sessionCookieManager) {
+        this.bffSessionProperties = bffSessionProperties;
+        this.sessionCookieManager = sessionCookieManager;
+    }
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain filterChain) throws ServletException, IOException {
+        if (!this.bffSessionProperties.getCsrf().isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        final BffResolvedSession resolvedSession = BffSessionContextHolder.get();
+        if (resolvedSession == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        final String path = this.resolvePath(request);
+        if (!this.requiresCsrf(path, request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        final String expectedToken = resolvedSession.getSession().getCsrfToken();
+        final String headerToken = request.getHeader(this.bffSessionProperties.getCsrf().getHeaderName());
+        final String cookieToken = this.readCookieValue(request, this.sessionCookieManager.csrfCookieName()).orElse(null);
+        if (expectedToken == null || !expectedToken.equals(headerToken) || !expectedToken.equals(cookieToken)) {
+            this.writeForbidden(response);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean requiresCsrf(final String path, final String method) {
+        final boolean protectedMethod = this.bffSessionProperties.getCsrf().getProtectedMethods().stream()
+                .anyMatch(value -> value.equalsIgnoreCase(method));
+        if (!protectedMethod) {
+            return false;
+        }
+        return this.bffSessionProperties.getCsrf().getIgnorePaths().stream()
+                .noneMatch(configuredPath -> this.matchesPath(path, configuredPath));
+    }
+
+    private boolean matchesPath(final String path, final String configuredPath) {
+        if (configuredPath.endsWith("/**")) {
+            return path.startsWith(configuredPath.substring(0, configuredPath.length() - 3));
+        }
+        return path.equals(configuredPath);
+    }
+
+    private String resolvePath(final HttpServletRequest request) {
+        final String contextPath = request.getContextPath();
+        final String requestUri = request.getRequestURI();
+        if (contextPath == null || contextPath.isBlank()) {
+            return requestUri;
+        }
+        if (!requestUri.startsWith(contextPath)) {
+            return requestUri;
+        }
+        final String result = requestUri.substring(contextPath.length());
+        return result.isBlank() ? "/" : result;
+    }
+
+    private Optional<String> readCookieValue(final HttpServletRequest request, final String cookieName) {
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookieName.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst();
+    }
+
+    private void writeForbidden(final HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("""
+                {"code":403,"title":"Forbidden","details":"Invalid CSRF token"}
+                """);
+    }
+}

--- a/boot/src/main/java/com/sitionix/bffssox/security/BffSessionAuthenticationFilter.java
+++ b/boot/src/main/java/com/sitionix/bffssox/security/BffSessionAuthenticationFilter.java
@@ -1,0 +1,150 @@
+package com.sitionix.bffssox.security;
+
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import com.sitionix.bffssox.domain.BffSessionManager;
+import com.sitionix.bffssox.domain.BffSessionProperties;
+import com.sitionix.bffssox.domain.SessionCookieManager;
+import com.sitionix.forge.security.userjwt.core.ForgeUser;
+import com.sitionix.forge.security.userjwt.web.UserJwtAuthenticationToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class BffSessionAuthenticationFilter extends OncePerRequestFilter {
+
+    private final BffSessionManager bffSessionManager;
+
+    private final BffSessionProperties bffSessionProperties;
+
+    private final SessionCookieManager sessionCookieManager;
+
+    public BffSessionAuthenticationFilter(final BffSessionManager bffSessionManager,
+                                          final BffSessionProperties bffSessionProperties,
+                                          final SessionCookieManager sessionCookieManager) {
+        this.bffSessionManager = bffSessionManager;
+        this.bffSessionProperties = bffSessionProperties;
+        this.sessionCookieManager = sessionCookieManager;
+    }
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain filterChain) throws ServletException, IOException {
+        final String path = this.resolvePath(request);
+        if (!path.startsWith("/api/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        final String sessionId = this.readCookieValue(request, this.sessionCookieManager.sessionCookieName()).orElse(null);
+        final Optional<BffResolvedSession> resolvedSession = sessionId == null
+                ? Optional.empty()
+                : this.bffSessionManager.resolveSession(
+                        sessionId,
+                        this.readUserAgent(request),
+                        request.getRemoteAddr()
+                );
+        if (resolvedSession.isPresent()) {
+            final BffResolvedSession session = resolvedSession.get();
+            if (session.getPreviousSessionId() != null) {
+                response.addHeader(HttpHeaders.SET_COOKIE, this.sessionCookieManager.createSessionCookie(session.getSessionId()));
+            }
+            response.addHeader(HttpHeaders.SET_COOKIE, this.sessionCookieManager.createCsrfCookie(session.getSession().getCsrfToken()));
+            BffSessionContextHolder.set(session);
+            SecurityContextHolder.getContext().setAuthentication(UserJwtAuthenticationToken.authenticated(
+                    new ForgeUser(
+                            session.getSession().getUserId(),
+                            session.getSession().getEmail(),
+                            List.of()
+                    )
+            ));
+        }
+        if (this.requiresAuthentication(path, request) && resolvedSession.isEmpty()) {
+            this.writeUnauthorized(response);
+            return;
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            BffSessionContextHolder.clear();
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    private boolean requiresAuthentication(final String path, final HttpServletRequest request) {
+        final String method = request.getMethod();
+        if ("OPTIONS".equalsIgnoreCase(method)) {
+            return false;
+        }
+        if (this.hasBearerAuthorization(request)) {
+            return false;
+        }
+        return this.bffSessionProperties.getPublicPaths().stream()
+                .noneMatch(publicPath -> this.matchesPath(path, publicPath));
+    }
+
+    private boolean hasBearerAuthorization(final HttpServletRequest request) {
+        final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return authorization != null && !authorization.isBlank();
+    }
+
+    private boolean matchesPath(final String path, final String configuredPath) {
+        if (configuredPath.endsWith("/**")) {
+            return path.startsWith(configuredPath.substring(0, configuredPath.length() - 3));
+        }
+        return path.equals(configuredPath);
+    }
+
+    private String resolvePath(final HttpServletRequest request) {
+        final String contextPath = request.getContextPath();
+        final String requestUri = request.getRequestURI();
+        if (contextPath == null || contextPath.isBlank()) {
+            return requestUri;
+        }
+        if (!requestUri.startsWith(contextPath)) {
+            return requestUri;
+        }
+        final String result = requestUri.substring(contextPath.length());
+        return result.isBlank() ? "/" : result;
+    }
+
+    private Optional<String> readCookieValue(final HttpServletRequest request, final String cookieName) {
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookieName.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst();
+    }
+
+    private String readUserAgent(final HttpServletRequest request) {
+        final String value = request.getHeader(HttpHeaders.USER_AGENT);
+        return value == null ? "" : value;
+    }
+
+    private void writeUnauthorized(final HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        response.addHeader(HttpHeaders.SET_COOKIE, this.sessionCookieManager.clearSessionCookie());
+        response.addHeader(HttpHeaders.SET_COOKIE, this.sessionCookieManager.clearCsrfCookie());
+        response.getWriter().write("""
+                {"code":401,"title":"unauthorized","details":"Authentication required"}
+                """);
+    }
+}

--- a/boot/src/main/java/com/sitionix/bffssox/security/BffUserTokenPropagationInterceptor.java
+++ b/boot/src/main/java/com/sitionix/bffssox/security/BffUserTokenPropagationInterceptor.java
@@ -1,0 +1,28 @@
+package com.sitionix.bffssox.security;
+
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class BffUserTokenPropagationInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(final HttpRequest request,
+                                        final byte[] body,
+                                        final ClientHttpRequestExecution execution) throws IOException {
+        final BffResolvedSession session = BffSessionContextHolder.get();
+        if (session != null && session.getSession() != null && session.getSession().getAccessToken() != null) {
+            request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + session.getSession().getAccessToken());
+            request.getHeaders().set("X-Forge-User-Sub", session.getSession().getUserId());
+        }
+        return execution.execute(request, body);
+    }
+}

--- a/boot/src/main/java/com/sitionix/bffssox/security/SessionCookieManagerImpl.java
+++ b/boot/src/main/java/com/sitionix/bffssox/security/SessionCookieManagerImpl.java
@@ -1,0 +1,76 @@
+package com.sitionix.bffssox.security;
+
+import com.sitionix.bffssox.domain.BffSessionProperties;
+import com.sitionix.bffssox.domain.SessionCookieManager;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class SessionCookieManagerImpl implements SessionCookieManager {
+
+    private final BffSessionProperties properties;
+
+    public SessionCookieManagerImpl(final BffSessionProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String sessionCookieName() {
+        return this.properties.getCookieName();
+    }
+
+    @Override
+    public String csrfCookieName() {
+        return this.properties.getCsrf().getCookieName();
+    }
+
+    @Override
+    public String createSessionCookie(final String sessionId) {
+        return ResponseCookie.from(this.properties.getCookieName(), sessionId)
+                .httpOnly(this.properties.isHttpOnly())
+                .secure(this.properties.isSecure())
+                .sameSite(this.properties.getSameSite())
+                .path("/")
+                .maxAge(Duration.ofSeconds(this.properties.getAbsoluteTimeoutSeconds()))
+                .build()
+                .toString();
+    }
+
+    @Override
+    public String clearSessionCookie() {
+        return ResponseCookie.from(this.properties.getCookieName(), "")
+                .httpOnly(this.properties.isHttpOnly())
+                .secure(this.properties.isSecure())
+                .sameSite(this.properties.getSameSite())
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .build()
+                .toString();
+    }
+
+    @Override
+    public String createCsrfCookie(final String csrfToken) {
+        return ResponseCookie.from(this.properties.getCsrf().getCookieName(), csrfToken)
+                .httpOnly(false)
+                .secure(this.properties.isSecure())
+                .sameSite(this.properties.getSameSite())
+                .path("/")
+                .maxAge(Duration.ofSeconds(this.properties.getAbsoluteTimeoutSeconds()))
+                .build()
+                .toString();
+    }
+
+    @Override
+    public String clearCsrfCookie() {
+        return ResponseCookie.from(this.properties.getCsrf().getCookieName(), "")
+                .httpOnly(false)
+                .secure(this.properties.isSecure())
+                .sameSite(this.properties.getSameSite())
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .build()
+                .toString();
+    }
+}

--- a/boot/src/main/resources/application-local.yml
+++ b/boot/src/main/resources/application-local.yml
@@ -1,0 +1,3 @@
+security:
+  session:
+    secure: false

--- a/boot/src/main/resources/application.yml
+++ b/boot/src/main/resources/application.yml
@@ -2,6 +2,34 @@ sitionix:
   cors:
     allowed-origins:
       - "http://localhost:3000"
+security:
+  session:
+    cookie-name: "__Host-admin_session"
+    same-site: "Lax"
+    secure: true
+    http-only: true
+    idle-timeout-seconds: 86400
+    absolute-timeout-seconds: 1209600
+    rotation-interval-seconds: 86400
+    refresh-skew-seconds: 60
+    touch-throttle-seconds: 30
+    public-paths:
+      - "/api/v1/session"
+      - "/api/v1/auth/login"
+      - "/api/v1/auth/refresh"
+      - "/api/v1/users"
+      - "/api/v1/auth/email/verify"
+    csrf:
+      enabled: true
+      cookie-name: "XSRF-TOKEN"
+      header-name: "X-CSRF"
+      protected-methods: [ "POST", "PUT", "PATCH", "DELETE" ]
+      ignore-paths:
+        - "/api/v1/auth/login"
+        - "/api/v1/users"
+        - "/api/v1/auth/email/verify"
+    session-store:
+      type: "inmemory"
 server:
   port: 8080
   servlet:

--- a/boot/src/test/java/com/sitionix/bffssox/it/utils/WireMockEndpoint.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/utils/WireMockEndpoint.java
@@ -25,8 +25,7 @@ public class WireMockEndpoint {
                     LoginRequestDTO.class,
                     LoginResponseDTO.class,
                     (WiremockDefault) context -> {
-                        context.matchesJson("requestDefaultMappingLoginUserWithHappyPath.json")
-                                .responseBody("responseDefaultMappingLoginUserWithHappyPath.json")
+                        context.responseBody("responseDefaultMappingLoginUserWithHappyPath.json")
                                 .plainUrl()
                                 .responseStatus(200);
                     });

--- a/boot/src/test/resources/application-it.yml
+++ b/boot/src/test/resources/application-it.yml
@@ -19,3 +19,8 @@ forge:
     targets:
       sitionixAuth:
         host: localhost
+security:
+  session:
+    secure: false
+    csrf:
+      enabled: false

--- a/boot/src/test/resources/forge-it/mockmvc/default/request/requestDefaultLoginUserWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/request/requestDefaultLoginUserWithHappyPath.json
@@ -1,7 +1,5 @@
 {
   "email": "user@example.com",
   "password": "StrongPassword123",
-  "siteId": "c9b1f3f4-12c7-11ec-82a8-0242ac130003",
-  "sessionSourceId": "chrome-uuid-12345",
-  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)..."
+  "siteId": "c9b1f3f4-12c7-11ec-82a8-0242ac130003"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultLoginUserWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultLoginUserWithHappyPath.json
@@ -1,6 +1,10 @@
 {
-  "accessToken": "eyJhbGciOi...",
-  "refreshToken": "dGhpc0lzUmVmcmVzaA==",
-  "expiresIn": 3600,
-  "tokenType": "Bearer"
+  "authenticated": true,
+  "user": {
+    "id": "it-user-123",
+    "email": "it-user-123@example.com",
+    "role": "SUPER_ADMIN",
+    "siteId": "c9b1f3f4-12c7-11ec-82a8-0242ac130003"
+  },
+  "idleTimeoutSeconds": 86400
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingLoginUserWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingLoginUserWithHappyPath.json
@@ -1,5 +1,5 @@
 {
-  "accessToken": "eyJhbGciOi...",
+  "accessToken": "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJpdC11c2VyLTEyMyIsImVtYWlsIjoiaXQtdXNlci0xMjNAZXhhbXBsZS5jb20iLCJyb2xlIjoiU1VQRVJfQURNSU4iLCJzaXRlSWQiOiJjOWIxZjNmNC0xMmM3LTExZWMtODJhOC0wMjQyYWMxMzAwMDMiLCJleHAiOjQxMDI0NDQ4MDB9.signature",
   "refreshToken": "dGhpc0lzUmVmcmVzaA==",
   "expiresIn": 3600,
   "tokenType": "Bearer"

--- a/clients/client-athssox/src/test/java/com/sitionix/bffssox/client/ClientCallExecutorTest.java
+++ b/clients/client-athssox/src/test/java/com/sitionix/bffssox/client/ClientCallExecutorTest.java
@@ -2,6 +2,7 @@ package com.sitionix.bffssox.client;
 
 import com.sitionix.bffssox.domain.ClientResponseException;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -15,20 +16,25 @@ class ClientCallExecutorTest {
 
     private ClientCallExecutor clientCallExecutor;
 
-    @org.junit.jupiter.api.BeforeEach
+    @BeforeEach
     void setUp() {
         this.clientCallExecutor = new ClientCallExecutor();
     }
 
     @Test
     void givenSuccessSupplier_whenExecute_thenReturnValue() {
+        //given
+
+        //when
         final String result = this.clientCallExecutor.execute(() -> "ok");
 
+        //then
         assertThat(result).isEqualTo("ok");
     }
 
     @Test
     void givenHttpError_whenExecute_thenThrowClientResponseExceptionWithBody() {
+        //given
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.add("X-Trace-Id", "trace-123");
@@ -41,6 +47,7 @@ class ClientCallExecutorTest {
                 StandardCharsets.UTF_8
         );
 
+        //when then
         assertThatThrownBy(() -> this.clientCallExecutor.execute(() -> {
             throw exception;
         }))

--- a/clients/client-stsssox/src/main/java/com/sitionix/bffssox/client/StsssoxClientCallExecutor.java
+++ b/clients/client-stsssox/src/main/java/com/sitionix/bffssox/client/StsssoxClientCallExecutor.java
@@ -1,17 +1,46 @@
 package com.sitionix.bffssox.client;
 
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import com.sitionix.bffssox.domain.BffSessionManager;
 import com.sitionix.bffssox.domain.ClientResponseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 
 @Component
+@RequiredArgsConstructor
 public class StsssoxClientCallExecutor {
+
+    private final BffSessionManager bffSessionManager;
 
     public <T> T execute(final Supplier<T> call) {
         try {
             return call.get();
         } catch (HttpStatusCodeException ex) {
+            if (ex.getStatusCode().value() == HttpStatus.UNAUTHORIZED.value()) {
+                final BffResolvedSession resolvedSession = BffSessionContextHolder.get();
+                if (resolvedSession != null) {
+                    final BffResolvedSession refreshedSession = this.bffSessionManager
+                            .refreshSession(resolvedSession.getSessionId(), true)
+                            .orElse(null);
+                    if (refreshedSession != null) {
+                        BffSessionContextHolder.set(refreshedSession);
+                        try {
+                            return call.get();
+                        } catch (HttpStatusCodeException retryEx) {
+                            throw new ClientResponseException(
+                                    retryEx.getStatusCode().value(),
+                                    retryEx.getResponseBodyAsString(),
+                                    retryEx.getResponseHeaders(),
+                                    retryEx
+                            );
+                        }
+                    }
+                }
+            }
             throw new ClientResponseException(
                     ex.getStatusCode().value(),
                     ex.getResponseBodyAsString(),

--- a/clients/client-stsssox/src/test/java/com/sitionix/bffssox/client/StsssoxClientCallExecutorTest.java
+++ b/clients/client-stsssox/src/test/java/com/sitionix/bffssox/client/StsssoxClientCallExecutorTest.java
@@ -1,9 +1,15 @@
 package com.sitionix.bffssox.client;
 
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import com.sitionix.bffssox.domain.BffSessionManager;
 import com.sitionix.bffssox.domain.ClientResponseException;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,20 +17,36 @@ import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
 
 class StsssoxClientCallExecutorTest {
 
     private StsssoxClientCallExecutor stsssoxClientCallExecutor;
 
+    @Mock
+    private BffSessionManager bffSessionManager;
+
     @BeforeEach
     void setUp() {
-        this.stsssoxClientCallExecutor = new StsssoxClientCallExecutor();
+        this.stsssoxClientCallExecutor = new StsssoxClientCallExecutor(this.bffSessionManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        BffSessionContextHolder.clear();
+        verifyNoMoreInteractions(this.bffSessionManager);
     }
 
     @Test
     void givenSuccessSupplier_whenExecute_thenReturnValue() {
+        //given
+
+        //when
         final String result = this.stsssoxClientCallExecutor.execute(() -> "ok");
 
+        //then
         assertThat(result).isEqualTo("ok");
     }
 

--- a/clients/client-wagssox/src/main/java/com/sitionix/bffssox/client/WagssoxClientCallExecutor.java
+++ b/clients/client-wagssox/src/main/java/com/sitionix/bffssox/client/WagssoxClientCallExecutor.java
@@ -1,17 +1,46 @@
 package com.sitionix.bffssox.client;
 
+import com.sitionix.bffssox.domain.BffResolvedSession;
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import com.sitionix.bffssox.domain.BffSessionManager;
 import com.sitionix.bffssox.domain.ClientResponseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 
 @Component
+@RequiredArgsConstructor
 public class WagssoxClientCallExecutor {
+
+    private final BffSessionManager bffSessionManager;
 
     public <T> T execute(final Supplier<T> call) {
         try {
             return call.get();
         } catch (HttpStatusCodeException ex) {
+            if (ex.getStatusCode().value() == HttpStatus.UNAUTHORIZED.value()) {
+                final BffResolvedSession resolvedSession = BffSessionContextHolder.get();
+                if (resolvedSession != null) {
+                    final BffResolvedSession refreshedSession = this.bffSessionManager
+                            .refreshSession(resolvedSession.getSessionId(), true)
+                            .orElse(null);
+                    if (refreshedSession != null) {
+                        BffSessionContextHolder.set(refreshedSession);
+                        try {
+                            return call.get();
+                        } catch (HttpStatusCodeException retryEx) {
+                            throw new ClientResponseException(
+                                    retryEx.getStatusCode().value(),
+                                    retryEx.getResponseBodyAsString(),
+                                    retryEx.getResponseHeaders(),
+                                    retryEx
+                            );
+                        }
+                    }
+                }
+            }
             throw new ClientResponseException(
                     ex.getStatusCode().value(),
                     ex.getResponseBodyAsString(),

--- a/clients/client-wagssox/src/test/java/com/sitionix/bffssox/client/WagssoxClientCallExecutorTest.java
+++ b/clients/client-wagssox/src/test/java/com/sitionix/bffssox/client/WagssoxClientCallExecutorTest.java
@@ -1,9 +1,15 @@
 package com.sitionix.bffssox.client;
 
+import com.sitionix.bffssox.domain.BffSessionContextHolder;
+import com.sitionix.bffssox.domain.BffSessionManager;
 import com.sitionix.bffssox.domain.ClientResponseException;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,14 +17,26 @@ import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
 
 class WagssoxClientCallExecutorTest {
 
     private WagssoxClientCallExecutor wagssoxClientCallExecutor;
 
+    @Mock
+    private BffSessionManager bffSessionManager;
+
     @BeforeEach
     void setUp() {
-        this.wagssoxClientCallExecutor = new WagssoxClientCallExecutor();
+        this.wagssoxClientCallExecutor = new WagssoxClientCallExecutor(this.bffSessionManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        BffSessionContextHolder.clear();
+        verifyNoMoreInteractions(this.bffSessionManager);
     }
 
     @Test

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffLoginSessionResult.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffLoginSessionResult.java
@@ -1,0 +1,15 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BffLoginSessionResult {
+
+    private String sessionId;
+
+    private SessionResponse response;
+
+    private String csrfToken;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffResolvedSession.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffResolvedSession.java
@@ -1,0 +1,15 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BffResolvedSession {
+
+    private String sessionId;
+
+    private String previousSessionId;
+
+    private BffSession session;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffSession.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffSession.java
@@ -1,0 +1,40 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder(toBuilder = true)
+public class BffSession {
+
+    private String userId;
+
+    private String email;
+
+    private String role;
+
+    private UUID siteId;
+
+    private String authSessionSourceId;
+
+    private String accessToken;
+
+    private Instant accessTokenExpiresAt;
+
+    private String refreshToken;
+
+    private Instant refreshTokenExpiresAt;
+
+    private String csrfToken;
+
+    private Instant createdAt;
+
+    private Instant lastUsedAt;
+
+    private Instant lastRotatedAt;
+
+    private Instant maxExpiresAt;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionContextHolder.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionContextHolder.java
@@ -1,0 +1,21 @@
+package com.sitionix.bffssox.domain;
+
+public final class BffSessionContextHolder {
+
+    private static final ThreadLocal<BffResolvedSession> HOLDER = new ThreadLocal<>();
+
+    private BffSessionContextHolder() {
+    }
+
+    public static void set(final BffResolvedSession session) {
+        HOLDER.set(session);
+    }
+
+    public static BffResolvedSession get() {
+        return HOLDER.get();
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionException.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionException.java
@@ -1,0 +1,8 @@
+package com.sitionix.bffssox.domain;
+
+public class BffSessionException extends RuntimeException {
+
+    public BffSessionException(final String message) {
+        super(message);
+    }
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionManager.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionManager.java
@@ -1,0 +1,45 @@
+package com.sitionix.bffssox.domain;
+
+import java.util.Optional;
+
+/**
+ * Manages cookie-backed server-side sessions for BFF authenticated flows.
+ */
+public interface BffSessionManager {
+
+    /**
+     * Authenticates the user via auth-service and creates a BFF session.
+     *
+     * @param request login payload.
+     * @param userAgent browser user-agent.
+     * @param remoteAddress client address.
+     * @return created session result.
+     */
+    BffLoginSessionResult createSession(LoginRequest request, String userAgent, String remoteAddress);
+
+    /**
+     * Resolves and validates a session from a cookie id.
+     *
+     * @param sessionId cookie session id.
+     * @param userAgent browser user-agent.
+     * @param remoteAddress client address.
+     * @return active resolved session if available.
+     */
+    Optional<BffResolvedSession> resolveSession(String sessionId, String userAgent, String remoteAddress);
+
+    /**
+     * Refreshes access token for an existing session.
+     *
+     * @param sessionId session id.
+     * @param forceRefresh true to force refresh even when access token is still valid.
+     * @return refreshed resolved session if refresh succeeds.
+     */
+    Optional<BffResolvedSession> refreshSession(String sessionId, boolean forceRefresh);
+
+    /**
+     * Invalidates and removes a session.
+     *
+     * @param sessionId session id.
+     */
+    void invalidateSession(String sessionId);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionProperties.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionProperties.java
@@ -1,0 +1,74 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "security.session")
+public class BffSessionProperties {
+
+    private String cookieName = "__Host-admin_session";
+
+    private String sameSite = "Lax";
+
+    private boolean secure = true;
+
+    private boolean httpOnly = true;
+
+    private long idleTimeoutSeconds = 86_400L;
+
+    private long absoluteTimeoutSeconds = 1_209_600L;
+
+    private long rotationIntervalSeconds = 86_400L;
+
+    private long refreshSkewSeconds = 60L;
+
+    private long touchThrottleSeconds = 30L;
+
+    private final List<String> publicPaths = new ArrayList<>(List.of(
+            "/api/v1/session",
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/users",
+            "/api/v1/auth/email/verify"
+    ));
+
+    private Csrf csrf = new Csrf();
+
+    private SessionStore sessionStore = new SessionStore();
+
+    @Data
+    public static class Csrf {
+        private boolean enabled = true;
+
+        private String cookieName = "XSRF-TOKEN";
+
+        private String headerName = "X-CSRF";
+
+        private List<String> protectedMethods = new ArrayList<>(List.of("POST", "PUT", "PATCH", "DELETE"));
+
+        private List<String> ignorePaths = new ArrayList<>(List.of(
+                "/api/v1/auth/login",
+                "/api/v1/users",
+                "/api/v1/auth/email/verify",
+                "/api/v1/auth/email/verify/resend"
+        ));
+    }
+
+    @Data
+    public static class SessionStore {
+        private String type = "inmemory";
+
+        private Redis redis = new Redis();
+    }
+
+    @Data
+    public static class Redis {
+        private String host = "localhost";
+
+        private int port = 6379;
+    }
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionStore.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/BffSessionStore.java
@@ -1,0 +1,58 @@
+package com.sitionix.bffssox.domain;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Stores and manages BFF server-side sessions by session identifier.
+ */
+public interface BffSessionStore {
+
+    /**
+     * Creates a new session record and returns generated session id.
+     *
+     * @param session session payload.
+     * @return generated session id.
+     */
+    String create(BffSession session);
+
+    /**
+     * Loads session by id.
+     *
+     * @param sessionId session id.
+     * @return optional session.
+     */
+    Optional<BffSession> get(String sessionId);
+
+    /**
+     * Replaces stored session payload by id.
+     *
+     * @param sessionId session id.
+     * @param session session payload.
+     */
+    void update(String sessionId, BffSession session);
+
+    /**
+     * Updates last-used timestamp for an existing session.
+     *
+     * @param sessionId session id.
+     * @param now timestamp.
+     */
+    void touch(String sessionId, Instant now);
+
+    /**
+     * Rotates session id while keeping payload.
+     *
+     * @param sessionId current session id.
+     * @param now rotation timestamp.
+     * @return new session id.
+     */
+    String rotate(String sessionId, Instant now);
+
+    /**
+     * Deletes session by id.
+     *
+     * @param sessionId session id.
+     */
+    void delete(String sessionId);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/SessionCookieManager.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/SessionCookieManager.java
@@ -1,0 +1,47 @@
+package com.sitionix.bffssox.domain;
+
+/**
+ * Produces HTTP Set-Cookie headers for BFF session and CSRF cookies.
+ */
+public interface SessionCookieManager {
+
+    /**
+     * @return session cookie name.
+     */
+    String sessionCookieName();
+
+    /**
+     * @return csrf cookie name.
+     */
+    String csrfCookieName();
+
+    /**
+     * Creates Set-Cookie header for active session.
+     *
+     * @param sessionId session id.
+     * @return Set-Cookie header value.
+     */
+    String createSessionCookie(String sessionId);
+
+    /**
+     * Creates Set-Cookie header for clearing active session.
+     *
+     * @return Set-Cookie header value.
+     */
+    String clearSessionCookie();
+
+    /**
+     * Creates Set-Cookie header for csrf token.
+     *
+     * @param csrfToken csrf token.
+     * @return Set-Cookie header value.
+     */
+    String createCsrfCookie(String csrfToken);
+
+    /**
+     * Creates Set-Cookie header to clear csrf token.
+     *
+     * @return Set-Cookie header value.
+     */
+    String clearCsrfCookie();
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/SessionResponse.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/SessionResponse.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class SessionResponse {
+
+    private Boolean authenticated;
+
+    private SessionUser user;
+
+    private Instant expiresAt;
+
+    private Long idleTimeoutSeconds;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/SessionUser.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/SessionUser.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Builder
+public class SessionUser {
+
+    private String id;
+
+    private String email;
+
+    private String role;
+
+    private UUID siteId;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/GetSession.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/GetSession.java
@@ -1,0 +1,10 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.BffResolvedSession;
+
+import java.util.Optional;
+
+public interface GetSession {
+
+    Optional<BffResolvedSession> execute(String sessionId, String userAgent, String remoteAddress);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/LoginUser.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/LoginUser.java
@@ -1,9 +1,9 @@
 package com.sitionix.bffssox.usecase;
 
+import com.sitionix.bffssox.domain.BffLoginSessionResult;
 import com.sitionix.bffssox.domain.LoginRequest;
-import com.sitionix.bffssox.domain.LoginResponse;
 
 public interface LoginUser {
 
-    LoginResponse execute(LoginRequest request);
+    BffLoginSessionResult execute(LoginRequest request, String userAgent, String remoteAddress);
 }


### PR DESCRIPTION
## Summary
- add server-side BFF session flow with cookie-based authentication
- add session middleware/security config and downstream token propagation updates
- update tests and test fixtures for new auth/session behavior

## Notes
- branch: feature/SITIONIX-90