### PR TITLE
[SITIONIX-95] - Fix upstream error mapping and align BFF IT expectations

### DIFF
--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/ClientResponseExceptionHandler.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/ClientResponseExceptionHandler.java
@@ -1,13 +1,16 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.ErrorDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sitionix.bffssox.domain.ClientResponseException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -17,7 +20,10 @@ import org.springframework.web.client.ResourceAccessException;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ClientResponseExceptionHandler {
+
+    private final ObjectMapper objectMapper;
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorDTO> handleBadRequest(final IllegalArgumentException ex) {
@@ -67,10 +73,31 @@ public class ClientResponseExceptionHandler {
 
     @ExceptionHandler(ClientResponseException.class)
     public ResponseEntity<ErrorDTO> handle(final ClientResponseException ex) {
-        final HttpStatus status = HttpStatus.SERVICE_UNAVAILABLE;
-        log.warn("Upstream error mapped to service unavailable: upstreamStatus={}, statusToClient={}",
-                ex.getStatusCode(), status.value());
-        return this.asErrorResponse(status, "Upstream service unavailable");
+        final HttpStatus status = HttpStatus.resolve(ex.getStatusCode());
+        if (status == null) {
+            log.warn("Unknown upstream status code: {}", ex.getStatusCode());
+            return this.asErrorResponse(HttpStatus.BAD_GATEWAY, "Invalid upstream response status");
+        }
+
+        final ErrorDTO upstreamError = this.parseError(ex.getResponseBody());
+        if (upstreamError != null) {
+            return ResponseEntity.status(status).body(upstreamError);
+        }
+
+        return this.asErrorResponse(status, status.getReasonPhrase());
+    }
+
+    private ErrorDTO parseError(final String responseBody) {
+        if (!StringUtils.hasText(responseBody)) {
+            return null;
+        }
+
+        try {
+            return this.objectMapper.readValue(responseBody, ErrorDTO.class);
+        } catch (Exception ex) {
+            log.warn("Failed to parse upstream error body", ex);
+            return null;
+        }
     }
 
     private ResponseEntity<ErrorDTO> asErrorResponse(final HttpStatus status, final String message) {

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/ClientResponseExceptionHandlerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/ClientResponseExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.ErrorDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sitionix.bffssox.domain.ClientResponseException;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +20,7 @@ class ClientResponseExceptionHandlerTest {
 
     @BeforeEach
     void setUp() {
-        this.clientResponseExceptionHandler = new ClientResponseExceptionHandler();
+        this.clientResponseExceptionHandler = new ClientResponseExceptionHandler(new ObjectMapper());
     }
 
     @Test
@@ -43,7 +44,7 @@ class ClientResponseExceptionHandlerTest {
     }
 
     @Test
-    void givenResourceAccessExceptionWithoutTimeoutCause_whenHandleResourceAccessException_thenReturnsServiceUnavailable() {
+    void givenResourceAccessException_whenHandleResourceAccessException_thenReturnsServiceUnavailable() {
         //given
         final ResourceAccessException exception = new ResourceAccessException("Connection refused");
 
@@ -62,29 +63,34 @@ class ClientResponseExceptionHandlerTest {
     }
 
     @Test
-    void givenResourceAccessExceptionWithTimeoutCause_whenHandleResourceAccessException_thenReturnsServiceUnavailable() {
+    void givenClientResponseExceptionWithUnauthorizedAndJsonBody_whenHandle_thenReturnsUnauthorizedWithUpstreamBody() {
         //given
-        final ResourceAccessException exception = new ResourceAccessException("Read timed out");
+        final ClientResponseException exception = new ClientResponseException(
+                HttpStatus.UNAUTHORIZED.value(),
+                "{\"code\":401,\"title\":\"unauthorized\",\"details\":\"Invalid credentials\"}",
+                Collections.emptyMap(),
+                new RuntimeException("Unauthorized")
+        );
 
         //when
-        final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handleResourceAccessException(exception);
+        final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handle(exception);
 
         //then
-        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(actual.getBody()).isEqualTo(
                 ErrorDTO.builder()
-                        .code(HttpStatus.SERVICE_UNAVAILABLE.value())
-                        .title(HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase())
-                        .details("Upstream service unavailable")
+                        .code(HttpStatus.UNAUTHORIZED.value())
+                        .title("unauthorized")
+                        .details("Invalid credentials")
                         .build()
         );
     }
 
     @Test
-    void givenClientResponseExceptionWithServerError_whenHandle_thenReturnsServiceUnavailable() {
+    void givenClientResponseExceptionWithServerErrorAndJsonBody_whenHandle_thenReturnsServerErrorWithUpstreamBody() {
         //given
         final ClientResponseException exception = new ClientResponseException(
-                HttpStatus.BAD_GATEWAY.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
                 "{\"code\":502,\"title\":\"upstream_error\",\"details\":\"AuthSox service failed\"}",
                 Collections.emptyMap(),
                 new RuntimeException("Upstream failed")
@@ -94,22 +100,22 @@ class ClientResponseExceptionHandlerTest {
         final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handle(exception);
 
         //then
-        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(actual.getBody()).isEqualTo(
                 ErrorDTO.builder()
-                        .code(HttpStatus.SERVICE_UNAVAILABLE.value())
-                        .title(HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase())
-                        .details("Upstream service unavailable")
+                        .code(502)
+                        .title("upstream_error")
+                        .details("AuthSox service failed")
                         .build()
         );
     }
 
     @Test
-    void givenClientResponseExceptionWithClientError_whenHandle_thenReturnsServiceUnavailable() {
+    void givenClientResponseExceptionWithInvalidJsonBody_whenHandle_thenReturnsFallbackError() {
         //given
         final ClientResponseException exception = new ClientResponseException(
                 HttpStatus.UNAUTHORIZED.value(),
-                "{\"code\":401,\"title\":\"Unauthorized\",\"details\":\"Bad token\"}",
+                "not-json",
                 Collections.emptyMap(),
                 new RuntimeException("Unauthorized")
         );
@@ -118,13 +124,38 @@ class ClientResponseExceptionHandlerTest {
         final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handle(exception);
 
         //then
-        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(actual.getBody()).isEqualTo(
                 ErrorDTO.builder()
-                        .code(HttpStatus.SERVICE_UNAVAILABLE.value())
-                        .title(HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase())
-                        .details("Upstream service unavailable")
+                        .code(HttpStatus.UNAUTHORIZED.value())
+                        .title(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                        .details(HttpStatus.UNAUTHORIZED.getReasonPhrase())
                         .build()
         );
     }
+
+    @Test
+    void givenClientResponseExceptionWithUnknownStatusCode_whenHandle_thenReturnsBadGatewayError() {
+        //given
+        final ClientResponseException exception = new ClientResponseException(
+                599,
+                "{\"code\":599,\"title\":\"unknown\",\"details\":\"Unknown status\"}",
+                Collections.emptyMap(),
+                new RuntimeException("Unknown")
+        );
+
+        //when
+        final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handle(exception);
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(actual.getBody()).isEqualTo(
+                ErrorDTO.builder()
+                        .code(HttpStatus.BAD_GATEWAY.value())
+                        .title(HttpStatus.BAD_GATEWAY.getReasonPhrase())
+                        .details("Invalid upstream response status")
+                        .build()
+        );
+    }
+
 }

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/AuthControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/AuthControllerIT.java
@@ -39,8 +39,8 @@ class AuthControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when invalid credentials are provided upstream")
-    void givenInvalidCredentials_whenLogin_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return unauthorized with body when invalid credentials are provided upstream")
+    void givenInvalidCredentials_whenLogin_thenReturnUnauthorizedWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_LOGIN_USER)
@@ -51,7 +51,7 @@ class AuthControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_LOGIN_USER)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
                         .expectResponse("responseDefaultLoginUserUnauthorized.json"))
                 .assertDefault();
 
@@ -76,8 +76,8 @@ class AuthControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when invalid verify email token is provided upstream")
-    void givenInvalidVerifyEmailToken_whenVerifyEmail_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return unauthorized with body when invalid verify email token is provided upstream")
+    void givenInvalidVerifyEmailToken_whenVerifyEmail_thenReturnUnauthorizedWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_VERIFY_EMAIL)
@@ -88,7 +88,7 @@ class AuthControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_VERIFY_EMAIL)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
                         .expectResponse("responseDefaultVerifyEmailUnauthorized.json"))
                 .assertDefault();
 
@@ -115,8 +115,8 @@ class AuthControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when invalid refresh token is provided upstream")
-    void givenInvalidRefreshAccessToken_whenRefreshAccessToken_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return unauthorized with body when invalid refresh token is provided upstream")
+    void givenInvalidRefreshAccessToken_whenRefreshAccessToken_thenReturnUnauthorizedWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_REFRESH_ACCESS_TOKEN)
@@ -127,7 +127,7 @@ class AuthControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_REFRESH_ACCESS_TOKEN)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
                         .expectResponse("responseDefaultRefreshAccessTokenUnauthorized.json"))
                 .assertDefault();
 

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/SiteControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/SiteControllerIT.java
@@ -47,8 +47,8 @@ class SiteControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when create site request is rejected upstream")
-    void givenUnauthorizedCreateSiteRequest_whenCreateSite_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return unauthorized with body when create site request is rejected upstream")
+    void givenUnauthorizedCreateSiteRequest_whenCreateSite_thenReturnUnauthorizedWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_CREATE_SITE)
@@ -59,7 +59,7 @@ class SiteControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_CREATE_SITE)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
                         .expectResponse("responseDefaultCreateSiteUnauthorizedUpstream.json"))
                 .assertDefault();
 
@@ -67,8 +67,8 @@ class SiteControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when site service fails")
-    void givenUpstreamServerError_whenCreateSite_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return internal server error with body when site service fails")
+    void givenUpstreamServerError_whenCreateSite_thenReturnInternalServerErrorWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_CREATE_SITE)
@@ -79,7 +79,7 @@ class SiteControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_CREATE_SITE)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
                         .expectResponse("responseDefaultCreateSiteBadGateway.json"))
                 .assertDefault();
 

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/UserControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/UserControllerIT.java
@@ -48,8 +48,8 @@ class UserControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when register request is rejected upstream")
-    void givenUnauthorizedRegisterRequest_whenRegisterUser_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return unauthorized with body when register request is rejected upstream")
+    void givenUnauthorizedRegisterRequest_whenRegisterUser_thenReturnUnauthorizedWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_REGISTER_USER)
@@ -60,7 +60,7 @@ class UserControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_REGISTER_USER)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
                         .expectResponse("responseDefaultRegisterUserUnauthorized.json"))
                 .assertDefault();
 
@@ -68,8 +68,8 @@ class UserControllerIT {
     }
 
     @Test
-    @DisplayName("Should return service unavailable with body when upstream fails")
-    void givenUpstreamServerError_whenRegisterUser_thenReturnServiceUnavailableWithBody() {
+    @DisplayName("Should return internal server error with body when upstream fails")
+    void givenUpstreamServerError_whenRegisterUser_thenReturnInternalServerErrorWithBody() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_REGISTER_USER)
@@ -80,7 +80,7 @@ class UserControllerIT {
         //when then
         this.testManager.mockMvc()
                 .ping(MockMvcEndpoint.POST_REGISTER_USER)
-                .applyDefault(context -> context.expectStatus(HttpStatus.SERVICE_UNAVAILABLE.value())
+                .applyDefault(context -> context.expectStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
                         .expectResponse("responseDefaultRegisterUserBadGateway.json"))
                 .assertDefault();
 

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultCreateSiteBadGateway.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultCreateSiteBadGateway.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 502,
+  "title": "upstream_error",
+  "details": "SiteSox service failed"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultCreateSiteUnauthorizedUpstream.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultCreateSiteUnauthorizedUpstream.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 401,
+  "title": "unauthorized",
+  "details": "Invalid access token"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultLoginUserUnauthorized.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultLoginUserUnauthorized.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 401,
+  "title": "unauthorized",
+  "details": "Invalid credentials"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultRefreshAccessTokenUnauthorized.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultRefreshAccessTokenUnauthorized.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 401,
+  "title": "unauthorized",
+  "details": "Invalid refresh token"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultRegisterUserBadGateway.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultRegisterUserBadGateway.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 502,
+  "title": "upstream_error",
+  "details": "AuthSox service failed"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultRegisterUserUnauthorized.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultRegisterUserUnauthorized.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 401,
+  "title": "unauthorized",
+  "details": "Invalid credentials"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultVerifyEmailUnauthorized.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultVerifyEmailUnauthorized.json
@@ -1,5 +1,5 @@
 {
-  "code": 503,
-  "title": "Service Unavailable",
-  "details": "Upstream service unavailable"
+  "code": 401,
+  "title": "unauthorized",
+  "details": "Invalid token"
 }


### PR DESCRIPTION
## Summary\n- return 503 only for real upstream unavailability (ResourceAccessException)\n- keep upstream HTTP status passthrough for ClientResponseException (401/4xx/5xx)\n- update handler unit tests and Forge IT expected responses\n\n## Validation\n- mvn clean install (backendforfrontendservice-sox)\n- mvn clean test (forge-end-to-end)