### PR TITLE
[SITIONIX-105] - switch bffssox api-first dependency to stable

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-sitionix-105-unstable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.1</atmssox.api.version>
+        <atmssox.api.version>0.0.4</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-sitionix-105-1-unstable</artifactId>
+            <artifactId>app-afesox-atmssox-client-stable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Summary:
- switch api-rest dependency from branch unstable artifact to stable artifact
- keep version on latest generated stable 0.0.19

Scope:
- only api-rest/pom.xml changed