### PR TITLE
[SITIONIX-112] - add bff patch agent proxy flow

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-sitionix-112-unstable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.19</bffssox.api.version>
+        <bffssox.api.version>0.0.22</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-112-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
@@ -4,14 +4,17 @@ import com.app_afesox.bffssox.api_first.api.AgentApi;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
+import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
 import com.sitionix.bffssox.usecase.GetAgents;
+import com.sitionix.bffssox.usecase.PatchAgent;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,10 @@ public class AgentController implements AgentApi {
     private final AgentApiMapper agentApiMapper;
 
     private final CreateAgent createAgent;
+
+    private final PatchAgentApiMapper patchAgentApiMapper;
+
+    private final PatchAgent patchAgent;
 
     private final GetAgents getAgents;
 
@@ -54,6 +61,13 @@ public class AgentController implements AgentApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<AgentDTO> getAgent(final UUID agentId) {
         final Agent response = this.getAgent.execute(agentId);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentDTO> patchAgent(final UUID agentId, @Valid final PatchAgentRequestDTO patchAgentRequestDTO) {
+        final Agent response = this.patchAgent.execute(agentId, this.patchAgentApiMapper.asPatchAgentRequest(patchAgentRequestDTO));
         return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
     }
 }

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/PatchAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/PatchAgentApiMapper.java
@@ -1,0 +1,11 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PatchAgentApiMapper {
+
+    PatchAgentRequest asPatchAgentRequest(PatchAgentRequestDTO src);
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -8,9 +8,11 @@ import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
+import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
 import com.sitionix.bffssox.usecase.GetAgents;
+import com.sitionix.bffssox.usecase.PatchAgent;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +44,12 @@ class AgentControllerTest {
     private CreateAgent createAgent;
 
     @Mock
+    private PatchAgentApiMapper patchAgentApiMapper;
+
+    @Mock
+    private PatchAgent patchAgent;
+
+    @Mock
     private GetAgents getAgents;
 
     @Mock
@@ -53,6 +61,8 @@ class AgentControllerTest {
                 this.createAgentApiMapper,
                 this.agentApiMapper,
                 this.createAgent,
+                this.patchAgentApiMapper,
+                this.patchAgent,
                 this.getAgents,
                 this.getAgent
         );
@@ -64,6 +74,8 @@ class AgentControllerTest {
                 this.createAgentApiMapper,
                 this.agentApiMapper,
                 this.createAgent,
+                this.patchAgentApiMapper,
+                this.patchAgent,
                 this.getAgents,
                 this.getAgent
         );

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -3,9 +3,11 @@ package com.sitionix.bffssox.controller;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
@@ -137,6 +139,29 @@ class AgentControllerTest {
         //then
         assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
         verify(this.getAgent).execute(agentId);
+        verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenPatchAgentRequestDto_whenPatchAgent_thenReturnOkResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("ebac37f0-90a2-4f6b-ab99-73f6ac5cf675");
+        final PatchAgentRequestDTO givenRequestDTO = mock(PatchAgentRequestDTO.class);
+        final PatchAgentRequest request = mock(PatchAgentRequest.class);
+        final Agent response = mock(Agent.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+
+        when(this.patchAgentApiMapper.asPatchAgentRequest(givenRequestDTO)).thenReturn(request);
+        when(this.patchAgent.execute(givenAgentId, request)).thenReturn(response);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentDTO> actual = this.agentController.patchAgent(givenAgentId, givenRequestDTO);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.patchAgentApiMapper).asPatchAgentRequest(givenRequestDTO);
+        verify(this.patchAgent).execute(givenAgentId, request);
         verify(this.agentApiMapper).asAgentDto(response);
     }
 }

--- a/application/src/main/java/com/sitionix/bffssox/usecase/PatchAgentImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/PatchAgentImpl.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PatchAgentImpl implements PatchAgent {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public Agent execute(final UUID agentId, final PatchAgentRequest request) {
+        return this.agentClient.patchAgent(agentId, request);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/PatchAgentImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/PatchAgentImplTest.java
@@ -1,0 +1,54 @@
+package com.sitionix.bffssox.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PatchAgentImplTest {
+
+    private PatchAgent patchAgent;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.patchAgent = new PatchAgentImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenPatchAgentRequest_whenExecute_thenReturnAgent() {
+        //given
+        final UUID givenAgentId = UUID.fromString("ebac37f0-90a2-4f6b-ab99-73f6ac5cf675");
+        final PatchAgentRequest givenRequest = mock(PatchAgentRequest.class);
+        final Agent expected = mock(Agent.class);
+        when(this.agentClient.patchAgent(givenAgentId, givenRequest)).thenReturn(expected);
+
+        //when
+        final Agent actual = this.patchAgent.execute(givenAgentId, givenRequest);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentClient).patchAgent(givenAgentId, givenRequest);
+    }
+}
+

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.4</atmssox.api.version>
+        <atmssox.api.version>0.0.5</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-112-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-sitionix-112-unstable</artifactId>
+            <artifactId>app-afesox-atmssox-client-stable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -4,12 +4,15 @@ import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
 import java.util.UUID;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
+import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +25,8 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     private final CreateAgentClientMapper createAgentClientMapper;
 
     private final AgentClientMapper agentClientMapper;
+
+    private final PatchAgentClientMapper patchAgentClientMapper;
 
     private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
 
@@ -44,6 +49,15 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     public Agent getAgent(final UUID agentId) {
         final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
                 () -> this.agentApi.getAgent(agentId)
+        );
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    @Override
+    public Agent patchAgent(final UUID agentId, final PatchAgentRequest request) {
+        final PatchAgentRequestDTO requestDTO = this.patchAgentClientMapper.asPatchAgentRequestDto(request);
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentApi.patchAgent(agentId, requestDTO)
         );
         return this.agentClientMapper.asAgent(responseDTO);
     }

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/PatchAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/PatchAgentClientMapper.java
@@ -1,0 +1,11 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PatchAgentClientMapper {
+
+    PatchAgentRequestDTO asPatchAgentRequestDto(PatchAgentRequest src);
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -9,6 +9,7 @@ import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
+import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
@@ -40,6 +41,9 @@ class AgentClientImplTest {
     private AgentClientMapper agentClientMapper;
 
     @Mock
+    private PatchAgentClientMapper patchAgentClientMapper;
+
+    @Mock
     private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
 
     @BeforeEach
@@ -48,6 +52,7 @@ class AgentClientImplTest {
                 this.agentApi,
                 this.createAgentClientMapper,
                 this.agentClientMapper,
+                this.patchAgentClientMapper,
                 this.atmssoxClientCallExecutor
         );
     }
@@ -58,6 +63,7 @@ class AgentClientImplTest {
                 this.agentApi,
                 this.createAgentClientMapper,
                 this.agentClientMapper,
+                this.patchAgentClientMapper,
                 this.atmssoxClientCallExecutor
         );
     }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -4,9 +4,11 @@ import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
 import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
@@ -139,6 +141,34 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(response);
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentApi).getAgent(agentId);
+        verify(this.agentClientMapper).asAgent(responseDTO);
+    }
+
+    @Test
+    void givenPatchAgentRequest_whenPatchAgent_thenReturnAgent() {
+        //given
+        final UUID givenAgentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final PatchAgentRequest request = mock(PatchAgentRequest.class);
+        final PatchAgentRequestDTO requestDTO = mock(PatchAgentRequestDTO.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final Agent expected = mock(Agent.class);
+
+        when(this.patchAgentClientMapper.asPatchAgentRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.patchAgent(givenAgentId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+
+        //when
+        final Agent actual = this.agentClient.patchAgent(givenAgentId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.patchAgentClientMapper).asPatchAgentRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).patchAgent(givenAgentId, requestDTO);
         verify(this.agentClientMapper).asAgent(responseDTO);
     }
 }

--- a/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
+++ b/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
@@ -3,6 +3,7 @@ package com.sitionix.bffssox.client;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
 import java.util.UUID;
 
 /**
@@ -32,4 +33,13 @@ public interface AgentClient {
      * @return persisted agent.
      */
     Agent getAgent(UUID agentId);
+
+    /**
+     * Applies partial identity update for one automation agent.
+     *
+     * @param agentId unique agent identifier.
+     * @param request partial update payload.
+     * @return updated agent.
+     */
+    Agent patchAgent(UUID agentId, PatchAgentRequest request);
 }

--- a/domain/src/main/java/com/sitionix/bffssox/domain/PatchAgentRequest.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/PatchAgentRequest.java
@@ -1,0 +1,13 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PatchAgentRequest {
+
+    private String name;
+
+    private String description;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/PatchAgent.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/PatchAgent.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import java.util.UUID;
+
+/**
+ * Use case for patching one automation agent identity.
+ */
+public interface PatchAgent {
+
+    /**
+     * Applies partial update for one automation agent.
+     *
+     * @param agentId agent identifier.
+     * @param request partial update payload.
+     * @return updated agent.
+     */
+    Agent execute(UUID agentId, PatchAgentRequest request);
+}


### PR DESCRIPTION
## Summary
- expose PATCH /api/v1/agents/{agentId} in bffssox
- keep controller/usecase thin and proxy-only
- forward patch request to atmssox client and return updated agent
- switch to unstable generated contracts for bffs api-first and atms client