### PR TITLE
[SITIONIX-113] - add lifecycle forwarding in bff

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.22</bffssox.api.version>
+        <bffssox.api.version>0.0.23</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-113-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
@@ -11,6 +11,8 @@ import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
+import com.sitionix.bffssox.usecase.ActivateAgent;
+import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
 import com.sitionix.bffssox.usecase.GetAgents;
@@ -41,6 +43,10 @@ public class AgentController implements AgentApi {
 
     private final GetAgent getAgent;
 
+    private final ActivateAgent activateAgent;
+
+    private final ArchiveAgent archiveAgent;
+
     @Override
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<AgentDTO> createAgent(@Valid final CreateAgentRequestDTO createAgentRequestDTO) {
@@ -61,6 +67,20 @@ public class AgentController implements AgentApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<AgentDTO> getAgent(final UUID agentId) {
         final Agent response = this.getAgent.execute(agentId);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentDTO> activateAgent(final UUID agentId) {
+        final Agent response = this.activateAgent.execute(agentId);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentDTO> archiveAgent(final UUID agentId) {
+        final Agent response = this.archiveAgent.execute(agentId);
         return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
     }
 

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -11,6 +11,8 @@ import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
+import com.sitionix.bffssox.usecase.ActivateAgent;
+import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
 import com.sitionix.bffssox.usecase.GetAgents;
@@ -57,6 +59,12 @@ class AgentControllerTest {
     @Mock
     private GetAgent getAgent;
 
+    @Mock
+    private ActivateAgent activateAgent;
+
+    @Mock
+    private ArchiveAgent archiveAgent;
+
     @BeforeEach
     void setUp() {
         this.agentController = new AgentController(
@@ -66,7 +74,9 @@ class AgentControllerTest {
                 this.patchAgentApiMapper,
                 this.patchAgent,
                 this.getAgents,
-                this.getAgent
+                this.getAgent,
+                this.activateAgent,
+                this.archiveAgent
         );
     }
 
@@ -79,7 +89,9 @@ class AgentControllerTest {
                 this.patchAgentApiMapper,
                 this.patchAgent,
                 this.getAgents,
-                this.getAgent
+                this.getAgent,
+                this.activateAgent,
+                this.archiveAgent
         );
     }
 

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -176,4 +176,42 @@ class AgentControllerTest {
         verify(this.patchAgent).execute(givenAgentId, request);
         verify(this.agentApiMapper).asAgentDto(response);
     }
+
+    @Test
+    void givenAgentId_whenActivateAgent_thenReturnOkResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        final Agent response = mock(Agent.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+
+        when(this.activateAgent.execute(givenAgentId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentDTO> actual = this.agentController.activateAgent(givenAgentId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.activateAgent).execute(givenAgentId);
+        verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenAgentId_whenArchiveAgent_thenReturnOkResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        final Agent response = mock(Agent.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+
+        when(this.archiveAgent.execute(givenAgentId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentDTO> actual = this.agentController.archiveAgent(givenAgentId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.archiveAgent).execute(givenAgentId);
+        verify(this.agentApiMapper).asAgentDto(response);
+    }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/ClientResponseExceptionHandlerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/ClientResponseExceptionHandlerTest.java
@@ -3,18 +3,26 @@ package com.sitionix.bffssox.controller;
 import com.app_afesox.bffssox.api_first.dto.ErrorDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sitionix.bffssox.domain.ClientResponseException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.client.ResourceAccessException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ClientResponseExceptionHandlerTest {
 
@@ -208,6 +216,110 @@ class ClientResponseExceptionHandlerTest {
                         .details("Invalid upstream response status")
                         .build()
         );
+    }
+
+    @Test
+    void givenIllegalArgumentException_whenHandleBadRequest_thenReturnsBadRequestError() {
+        //given
+        final IllegalArgumentException exception = new IllegalArgumentException("invalid payload");
+
+        //when
+        final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handleBadRequest(exception);
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(actual.getBody()).isEqualTo(
+                ErrorDTO.builder()
+                        .code(HttpStatus.BAD_REQUEST.value())
+                        .title(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .details("invalid payload")
+                        .build()
+        );
+    }
+
+    @Test
+    void givenConstraintViolationException_whenHandleConstraintViolationException_thenReturnsFirstViolationMessage() {
+        //given
+        final ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getMessage()).thenReturn("must not be blank");
+        final ConstraintViolationException exception = new ConstraintViolationException("invalid", Set.of(violation));
+
+        //when
+        final ResponseEntity<ErrorDTO> actual =
+                this.clientResponseExceptionHandler.handleConstraintViolationException(exception);
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(actual.getBody()).isEqualTo(
+                ErrorDTO.builder()
+                        .code(HttpStatus.BAD_REQUEST.value())
+                        .title(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .details("must not be blank")
+                        .build()
+        );
+    }
+
+    @Test
+    void givenMethodArgumentNotValidException_whenHandleValidationException_thenReturnsBindingMessage() {
+        //given
+        final BindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+        bindingResult.reject("invalid", "payload validation failed");
+        final MethodArgumentNotValidException exception =
+                new MethodArgumentNotValidException(mock(MethodParameter.class), bindingResult);
+
+        //when
+        final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handleValidationException(exception);
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(actual.getBody()).isEqualTo(
+                ErrorDTO.builder()
+                        .code(HttpStatus.BAD_REQUEST.value())
+                        .title(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .details("payload validation failed")
+                        .build()
+        );
+    }
+
+    @Test
+    void givenUnknownValidationException_whenHandleValidationException_thenReturnsFallbackMessage() {
+        //given
+        final Exception exception = new RuntimeException("unknown");
+
+        //when
+        final ResponseEntity<ErrorDTO> actual = this.clientResponseExceptionHandler.handleValidationException(exception);
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(actual.getBody()).isEqualTo(
+                ErrorDTO.builder()
+                        .code(HttpStatus.BAD_REQUEST.value())
+                        .title(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .details("Validation failed")
+                        .build()
+        );
+    }
+
+    @Test
+    void givenInvalidUnknownParameter_whenHandleMethodArgumentTypeMismatchException_thenReturnsBadRequestWithExceptionMessage() {
+        //given
+        final MethodArgumentTypeMismatchException exception = new MethodArgumentTypeMismatchException(
+                "abc",
+                UUID.class,
+                "otherParam",
+                null,
+                new IllegalArgumentException("Type mismatch details")
+        );
+
+        //when
+        final ResponseEntity<ErrorDTO> actual =
+                this.clientResponseExceptionHandler.handleMethodArgumentTypeMismatchException(exception);
+
+        //then
+        assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(actual.getBody().getCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(actual.getBody().getTitle()).isEqualTo(HttpStatus.BAD_REQUEST.getReasonPhrase());
+        assertThat(actual.getBody().getDetails()).contains("Type mismatch details");
     }
 
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentApiMapperTest.java
@@ -1,0 +1,123 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.bffssox.api_first.dto.AgentDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.AgentStatus;
+import com.sitionix.bffssox.domain.AgentsResponse;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class AgentApiMapperTest {
+
+    private AgentApiMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new AgentApiMapperImpl();
+    }
+
+    @Test
+    void givenAgent_whenAsAgentDto_thenReturnAgentDto() {
+        //given
+        final Agent given = this.agent();
+        final AgentDTO expected = this.agentDto();
+
+        //when
+        final AgentDTO actual = this.mapper.asAgentDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenAgentsResponse_whenAsAgentsResponseDto_thenReturnAgentsResponseDto() {
+        //given
+        final AgentsResponse given = AgentsResponse.builder()
+                .items(List.of(this.agent()))
+                .build();
+        final AgentsResponseDTO expected = AgentsResponseDTO.builder()
+                .items(List.of(this.agentDto()))
+                .build();
+
+        //when
+        final AgentsResponseDTO actual = this.mapper.asAgentsResponseDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullAgent_whenAsAgentDto_thenReturnNull() {
+        //given
+        final Agent given = null;
+
+        //when
+        final AgentDTO actual = this.mapper.asAgentDto(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenNullAgentsResponse_whenAsAgentsResponseDto_thenReturnNull() {
+        //given
+        final AgentsResponse given = null;
+
+        //when
+        final AgentsResponseDTO actual = this.mapper.asAgentsResponseDto(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenAgentWithArchivedStatusAndNullId_whenAsAgentDto_thenReturnArchivedStatusAndNullId() {
+        //given
+        final Agent given = Agent.builder()
+                .id(null)
+                .name("A")
+                .description("D")
+                .status(AgentStatus.ARCHIVED)
+                .createdAt(OffsetDateTime.parse("2026-04-10T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-10T10:01:00Z"))
+                .build();
+
+        //when
+        final AgentDTO actual = this.mapper.asAgentDto(given);
+
+        //then
+        assertThat(actual.getId()).isNull();
+        assertThat(actual.getStatus()).isEqualTo(AgentDTO.StatusEnum.ARCHIVED);
+    }
+
+    private Agent agent() {
+        return Agent.builder()
+                .id("f2f2b8c4-5039-4095-b5ec-d584bd429ca3")
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .status(AgentStatus.ACTIVE)
+                .createdAt(OffsetDateTime.parse("2026-04-10T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-10T10:01:00Z"))
+                .build();
+    }
+
+    private AgentDTO agentDto() {
+        return AgentDTO.builder()
+                .id(UUID.fromString("f2f2b8c4-5039-4095-b5ec-d584bd429ca3"))
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .status(AgentDTO.StatusEnum.ACTIVE)
+                .createdAt(OffsetDateTime.parse("2026-04-10T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-10T10:01:00Z"))
+                .build();
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/CreateAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/CreateAgentApiMapperTest.java
@@ -1,0 +1,52 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
+import com.sitionix.bffssox.domain.CreateAgentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class CreateAgentApiMapperTest {
+
+    private CreateAgentApiMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new CreateAgentApiMapperImpl();
+    }
+
+    @Test
+    void givenCreateAgentRequestDto_whenAsCreateAgentRequest_thenReturnCreateAgentRequest() {
+        //given
+        final CreateAgentRequestDTO given = CreateAgentRequestDTO.builder()
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .build();
+        final CreateAgentRequest expected = CreateAgentRequest.builder()
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .build();
+
+        //when
+        final CreateAgentRequest actual = this.mapper.asCreateAgentRequest(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullCreateAgentRequestDto_whenAsCreateAgentRequest_thenReturnNull() {
+        //given
+        final CreateAgentRequestDTO given = null;
+
+        //when
+        final CreateAgentRequest actual = this.mapper.asCreateAgentRequest(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/CreateSiteApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/CreateSiteApiMapperTest.java
@@ -52,6 +52,85 @@ class CreateSiteApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final CreateSiteRequestDTO createSiteRequestDTO = null;
+        final CreateSiteResponse createSiteResponse = null;
+
+        //when
+        final CreateSiteRequest actualRequest = this.mapper.asCreateSiteRequest(createSiteRequestDTO);
+        final CreateSiteResponseDTO actualResponse = this.mapper.asCreateSiteResponseDto(createSiteResponse);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenAllTypeAndStatusVariants_whenMap_thenReturnMappedVariants() {
+        //given
+        final CreateSiteRequestDTO requestDTO = CreateSiteRequestDTO.builder()
+                .name("n")
+                .type(CreateSiteRequestDTO.TypeEnum.OTHER)
+                .description("d")
+                .template(CreateSiteRequestDTO.TemplateEnum.BLANK)
+                .build();
+        final CreateSiteResponse response = CreateSiteResponse.builder()
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .name("s")
+                .status(SiteStatus.ARCHIVED)
+                .createdAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"))
+                .build();
+
+        //when
+        final CreateSiteRequest request = this.mapper.asCreateSiteRequest(requestDTO);
+        final CreateSiteResponseDTO responseDTO = this.mapper.asCreateSiteResponseDto(response);
+
+        //then
+        assertThat(request.getType()).isEqualTo(SiteType.OTHER);
+        assertThat(request.getTemplate()).isEqualTo(SiteTemplate.BLANK);
+        assertThat(responseDTO.getStatus()).isEqualTo(CreateSiteResponseDTO.StatusEnum.ARCHIVED);
+    }
+
+    @Test
+    void givenAllEnums_whenMap_thenReturnMappedEnums() {
+        //given
+        final CreateSiteResponse baseResponse = CreateSiteResponse.builder()
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000010"))
+                .name("s")
+                .createdAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"))
+                .build();
+
+        //when
+        for (final CreateSiteRequestDTO.TypeEnum typeEnum : CreateSiteRequestDTO.TypeEnum.values()) {
+            final CreateSiteRequestDTO requestDTO = CreateSiteRequestDTO.builder()
+                    .name("n")
+                    .type(typeEnum)
+                    .description("d")
+                    .template(CreateSiteRequestDTO.TemplateEnum.BLANK)
+                    .build();
+            final CreateSiteRequest actualRequest = this.mapper.asCreateSiteRequest(requestDTO);
+            assertThat(actualRequest.getType().name()).isEqualTo(typeEnum.name());
+        }
+        for (final SiteStatus status : SiteStatus.values()) {
+            final CreateSiteResponse response = CreateSiteResponse.builder()
+                    .siteId(baseResponse.getSiteId())
+                    .name(baseResponse.getName())
+                    .status(status)
+                    .createdAt(baseResponse.getCreatedAt())
+                    .updatedAt(baseResponse.getUpdatedAt())
+                    .build();
+            final CreateSiteResponseDTO actualResponse = this.mapper.asCreateSiteResponseDto(response);
+            assertThat(actualResponse.getStatus().name()).isEqualTo(status.name());
+        }
+
+        //then
+        assertThat(CreateSiteRequestDTO.TemplateEnum.BLANK.name()).isEqualTo(SiteTemplate.BLANK.name());
+    }
+
     private CreateSiteRequestDTO createSiteRequestDTO() {
         return CreateSiteRequestDTO.builder()
                 .name("My portfolio")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/EmailVerificationApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/EmailVerificationApiMapperTest.java
@@ -51,6 +51,55 @@ class EmailVerificationApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final EmailVerificationDTO emailVerificationDTO = null;
+        final EmailVerificationResponse emailVerificationResponse = null;
+
+        //when
+        final EmailVerificationRequest actualRequest = this.mapper.asEmailVerificationRequest(emailVerificationDTO);
+        final EmailVerificationResponseDTO actualResponse = this.mapper.asEmailVerificationResponseDTO(emailVerificationResponse);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenPendingEmailVerifyStatus_whenAsEmailVerificationResponseDTO_thenReturnPendingEmailVerify() {
+        //given
+        final EmailVerificationResponse given = EmailVerificationResponse.builder()
+                .message("pending")
+                .status(EmailVerificationStatus.PENDING_EMAIL_VERIFY)
+                .build();
+
+        //when
+        final EmailVerificationResponseDTO actual = this.mapper.asEmailVerificationResponseDTO(given);
+
+        //then
+        assertThat(actual.getStatus()).isEqualTo(EmailVerificationResponseDTO.StatusEnum.PENDING_EMAIL_VERIFY);
+    }
+
+    @Test
+    void givenAllStatuses_whenAsEmailVerificationResponseDTO_thenReturnMappedStatuses() {
+        //given
+        final String message = "m";
+
+        //when
+        for (final EmailVerificationStatus status : EmailVerificationStatus.values()) {
+            final EmailVerificationResponse given = EmailVerificationResponse.builder()
+                    .message(message)
+                    .status(status)
+                    .build();
+            final EmailVerificationResponseDTO actual = this.mapper.asEmailVerificationResponseDTO(given);
+            assertThat(actual.getStatus().name()).isEqualTo(status.name());
+        }
+
+        //then
+        assertThat(EmailVerificationStatus.values().length).isGreaterThan(0);
+    }
+
     private EmailVerificationDTO emailVerificationDTO(final UUID uuid) {
         return EmailVerificationDTO.builder()
                 .token("token")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/LoginUserApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/LoginUserApiMapperTest.java
@@ -50,6 +50,21 @@ class LoginUserApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final LoginRequestDTO loginRequestDTO = null;
+        final LoginResponse loginResponse = null;
+
+        //when
+        final LoginRequest actualRequest = this.mapper.asLoginRequest(loginRequestDTO);
+        final LoginResponseDTO actualResponse = this.mapper.asLoginResponseDTO(loginResponse);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
     private LoginRequestDTO loginRequestDTO(final UUID uuid) {
         return LoginRequestDTO.builder()
                 .email("email")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/PatchAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/PatchAgentApiMapperTest.java
@@ -1,0 +1,52 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class PatchAgentApiMapperTest {
+
+    private PatchAgentApiMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new PatchAgentApiMapperImpl();
+    }
+
+    @Test
+    void givenPatchAgentRequestDto_whenAsPatchAgentRequest_thenReturnPatchAgentRequest() {
+        //given
+        final PatchAgentRequestDTO given = PatchAgentRequestDTO.builder()
+                .name("Updated Architecture Reviewer")
+                .description("Updated description")
+                .build();
+        final PatchAgentRequest expected = PatchAgentRequest.builder()
+                .name("Updated Architecture Reviewer")
+                .description("Updated description")
+                .build();
+
+        //when
+        final PatchAgentRequest actual = this.mapper.asPatchAgentRequest(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullPatchAgentRequestDto_whenAsPatchAgentRequest_thenReturnNull() {
+        //given
+        final PatchAgentRequestDTO given = null;
+
+        //when
+        final PatchAgentRequest actual = this.mapper.asPatchAgentRequest(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/RefreshAccessTokenApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/RefreshAccessTokenApiMapperTest.java
@@ -48,6 +48,73 @@ class RefreshAccessTokenApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final RefreshAccessTokenRequestDTO refreshAccessTokenRequestDTO = null;
+        final RefreshAccessTokenResponse refreshAccessTokenResponse = null;
+
+        //when
+        final RefreshAccessTokenRequest actualRequest =
+                this.mapper.asRefreshAccessTokenRequest("refreshToken", refreshAccessTokenRequestDTO);
+        final RefreshAccessTokenResponseDTO actualResponse = this.mapper.asRefreshAccessTokenResponseDTO(refreshAccessTokenResponse);
+
+        //then
+        assertThat(actualRequest).isEqualTo(RefreshAccessTokenRequest.builder()
+                .refreshToken("refreshToken")
+                .sessionSourceId(null)
+                .build());
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenTokenType_whenAsTokenTypeEnum_thenReturnEnum() {
+        //given
+        final String given = "Bearer";
+
+        //when
+        final RefreshAccessTokenResponseDTO.TokenTypeEnum actual = this.mapper.asTokenTypeEnum(given);
+
+        //then
+        assertThat(actual).isEqualTo(RefreshAccessTokenResponseDTO.TokenTypeEnum.BEARER);
+    }
+
+    @Test
+    void givenNullTokenType_whenAsTokenTypeEnum_thenReturnNull() {
+        //given
+        final String given = null;
+
+        //when
+        final RefreshAccessTokenResponseDTO.TokenTypeEnum actual = this.mapper.asTokenTypeEnum(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenTokenTypeEnum_whenAsTokenTypeValue_thenReturnValue() {
+        //given
+        final RefreshAccessTokenResponseDTO.TokenTypeEnum given = RefreshAccessTokenResponseDTO.TokenTypeEnum.BEARER;
+
+        //when
+        final String actual = this.mapper.asTokenTypeValue(given);
+
+        //then
+        assertThat(actual).isEqualTo("Bearer");
+    }
+
+    @Test
+    void givenNullTokenTypeEnum_whenAsTokenTypeValue_thenReturnNull() {
+        //given
+        final RefreshAccessTokenResponseDTO.TokenTypeEnum given = null;
+
+        //when
+        final String actual = this.mapper.asTokenTypeValue(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
     private RefreshAccessTokenRequestDTO refreshAccessTokenRequestDTO() {
         return RefreshAccessTokenRequestDTO.builder()
                 .sessionSourceId("sessionSourceId")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/RegisterUserApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/RegisterUserApiMapperTest.java
@@ -52,6 +52,75 @@ class RegisterUserApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final RegisterUserDTO registerUserDTO = null;
+        final RegisterUserResponse registerUserResponse = null;
+
+        //when
+        final RegisterUserRequest actualRequest = this.mapper.asRegisterUserRequest(registerUserDTO);
+        final ResponseRegisterUserDTO actualResponse = this.mapper.asResponseRegisterUserDto(registerUserResponse);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenAllRoleAndStatusVariants_whenMap_thenReturnMappedVariants() {
+        //given
+        final RegisterUserDTO request = RegisterUserDTO.builder()
+                .email("e")
+                .password("p")
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .role(RegisterUserDTO.RoleEnum.ECOSYSTEM_OWNER)
+                .build();
+        final RegisterUserResponse response = RegisterUserResponse.builder()
+                .message("m")
+                .status(RegisterUserStatus.BANNED)
+                .userId(1L)
+                .build();
+
+        //when
+        final RegisterUserRequest actualRequest = this.mapper.asRegisterUserRequest(request);
+        final ResponseRegisterUserDTO actualResponse = this.mapper.asResponseRegisterUserDto(response);
+
+        //then
+        assertThat(actualRequest.getRole()).isEqualTo(RegisterUserRole.ECOSYSTEM_OWNER);
+        assertThat(actualResponse.getStatus()).isEqualTo(ResponseRegisterUserDTO.StatusEnum.BANNED);
+    }
+
+    @Test
+    void givenAllEnums_whenMap_thenReturnMappedEnums() {
+        //given
+        final UUID siteId = UUID.fromString("00000000-0000-0000-0000-000000000005");
+
+        //when
+        for (final RegisterUserDTO.RoleEnum roleEnum : RegisterUserDTO.RoleEnum.values()) {
+            final RegisterUserDTO request = RegisterUserDTO.builder()
+                    .email("e")
+                    .password("p")
+                    .siteId(siteId)
+                    .role(roleEnum)
+                    .build();
+            final RegisterUserRequest actualRequest = this.mapper.asRegisterUserRequest(request);
+            assertThat(actualRequest.getRole().name()).isEqualTo(roleEnum.name());
+        }
+        for (final RegisterUserStatus status : RegisterUserStatus.values()) {
+            final RegisterUserResponse response = RegisterUserResponse.builder()
+                    .message("m")
+                    .status(status)
+                    .userId(1L)
+                    .build();
+            final ResponseRegisterUserDTO actualResponse = this.mapper.asResponseRegisterUserDto(response);
+            assertThat(actualResponse.getStatus().name()).isEqualTo(status.name());
+        }
+
+        //then
+        assertThat(RegisterUserStatus.values().length).isGreaterThan(0);
+    }
+
     private RegisterUserDTO registerUserDTO(final UUID uuid) {
         return RegisterUserDTO.builder()
                 .email("email")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ResendEmailVerificationApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ResendEmailVerificationApiMapperTest.java
@@ -33,6 +33,19 @@ class ResendEmailVerificationApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullResponse_whenAsResendEmailVerificationResponseDto_thenReturnNull() {
+        //given
+        final ResendEmailVerificationResponse given = null;
+
+        //when
+        final ResendEmailVerificationResponseDTO actual =
+                this.mapper.asResendEmailVerificationResponseDTO(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
     private ResendEmailVerificationResponse resendEmailVerificationResponse() {
         return ResendEmailVerificationResponse.builder()
                 .message("message")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/SiteOverviewApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/SiteOverviewApiMapperTest.java
@@ -36,6 +36,78 @@ class SiteOverviewApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullSiteOverview_whenAsSiteOverviewDto_thenReturnNull() {
+        //given
+        final SiteOverview siteOverview = null;
+
+        //when
+        final SiteOverviewDTO actual = this.mapper.asSiteOverviewDto(siteOverview);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenSiteOverviewWithArchivedStatusAndOtherType_whenAsSiteOverviewDto_thenReturnMappedEnums() {
+        //given
+        final SiteOverview siteOverview = SiteOverview.builder()
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .name("Archived Site")
+                .status(SiteStatus.ARCHIVED)
+                .type(SiteType.OTHER)
+                .description("d")
+                .createdAt(OffsetDateTime.parse("2026-01-10T12:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-01-29T08:30:00Z"))
+                .build();
+
+        //when
+        final SiteOverviewDTO actual = this.mapper.asSiteOverviewDto(siteOverview);
+
+        //then
+        assertThat(actual.getStatus()).isEqualTo(SiteOverviewDTO.StatusEnum.ARCHIVED);
+        assertThat(actual.getType()).isEqualTo(SiteOverviewDTO.TypeEnum.OTHER);
+    }
+
+    @Test
+    void givenAllEnums_whenAsSiteOverviewDto_thenReturnMappedEnums() {
+        //given
+        final UUID siteId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        final OffsetDateTime createdAt = OffsetDateTime.parse("2026-01-10T12:00:00Z");
+        final OffsetDateTime updatedAt = OffsetDateTime.parse("2026-01-29T08:30:00Z");
+
+        //when
+        for (final SiteStatus status : SiteStatus.values()) {
+            final SiteOverview siteOverview = SiteOverview.builder()
+                    .siteId(siteId)
+                    .name("n")
+                    .status(status)
+                    .type(SiteType.PORTFOLIO)
+                    .description("d")
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt)
+                    .build();
+            final SiteOverviewDTO actual = this.mapper.asSiteOverviewDto(siteOverview);
+            assertThat(actual.getStatus().name()).isEqualTo(status.name());
+        }
+        for (final SiteType type : SiteType.values()) {
+            final SiteOverview siteOverview = SiteOverview.builder()
+                    .siteId(siteId)
+                    .name("n")
+                    .status(SiteStatus.DRAFT)
+                    .type(type)
+                    .description("d")
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt)
+                    .build();
+            final SiteOverviewDTO actual = this.mapper.asSiteOverviewDto(siteOverview);
+            assertThat(actual.getType().name()).isEqualTo(type.name());
+        }
+
+        //then
+        assertThat(SiteType.values().length).isGreaterThan(0);
+    }
+
     private SiteOverview getSiteOverview() {
         return SiteOverview.builder()
                 .siteId(UUID.fromString("c9b1f3f4-12c7-11ec-82a8-0242ac130003"))

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/WorkspaceApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/WorkspaceApiMapperTest.java
@@ -39,6 +39,48 @@ class WorkspaceApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullWorkspaceSitesPage_whenAsWorkspaceSitesResponseDto_thenReturnNull() {
+        //given
+        final WorkspaceSitesPage workspaceSitesPage = null;
+
+        //when
+        final WorkspaceSitesResponseDTO actual = this.mapper.asWorkspaceSitesResponseDto(workspaceSitesPage);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenWorkspaceSitesPageWithAllStatusAndTypeVariants_whenAsWorkspaceSitesResponseDto_thenReturnMappedVariants() {
+        //given
+        final WorkspaceSitesPage workspaceSitesPage = WorkspaceSitesPage.builder()
+                .items(List.of(
+                        this.workspaceSiteCard(UUID.fromString("00000000-0000-0000-0000-000000000001"), SiteStatus.DRAFT, SiteType.PORTFOLIO),
+                        this.workspaceSiteCard(UUID.fromString("00000000-0000-0000-0000-000000000002"), SiteStatus.PUBLISHED, SiteType.BUSINESS),
+                        this.workspaceSiteCard(UUID.fromString("00000000-0000-0000-0000-000000000003"), SiteStatus.ARCHIVED, SiteType.OTHER),
+                        this.workspaceSiteCard(UUID.fromString("00000000-0000-0000-0000-000000000004"), null, null)
+                ))
+                .page(1)
+                .size(10)
+                .hasNext(false)
+                .build();
+
+        //when
+        final WorkspaceSitesResponseDTO actual = this.mapper.asWorkspaceSitesResponseDto(workspaceSitesPage);
+
+        //then
+        assertThat(actual.getItems()).hasSize(4);
+        assertThat(actual.getItems().get(0).getStatus()).isEqualTo(WorkspaceSiteCardResponseDTO.StatusEnum.DRAFT);
+        assertThat(actual.getItems().get(1).getStatus()).isEqualTo(WorkspaceSiteCardResponseDTO.StatusEnum.PUBLISHED);
+        assertThat(actual.getItems().get(2).getStatus()).isEqualTo(WorkspaceSiteCardResponseDTO.StatusEnum.ARCHIVED);
+        assertThat(actual.getItems().get(3).getStatus()).isNull();
+        assertThat(actual.getItems().get(0).getType()).isEqualTo(WorkspaceSiteCardResponseDTO.TypeEnum.PORTFOLIO);
+        assertThat(actual.getItems().get(1).getType()).isEqualTo(WorkspaceSiteCardResponseDTO.TypeEnum.BUSINESS);
+        assertThat(actual.getItems().get(2).getType()).isEqualTo(WorkspaceSiteCardResponseDTO.TypeEnum.OTHER);
+        assertThat(actual.getItems().get(3).getType()).isNull();
+    }
+
     private WorkspaceSitesPage getWorkspaceSitesPage() {
         return WorkspaceSitesPage.builder()
                 .items(List.of(WorkspaceSiteCard.builder()
@@ -69,5 +111,17 @@ class WorkspaceApiMapperTest {
                 .page(0)
                 .size(20)
                 .hasNext(true);
+    }
+
+    private WorkspaceSiteCard workspaceSiteCard(final UUID siteId, final SiteStatus status, final SiteType type) {
+        return WorkspaceSiteCard.builder()
+                .siteId(siteId)
+                .name("Agency Portfolio")
+                .status(status)
+                .type(type)
+                .description(null)
+                .createdAt(OffsetDateTime.parse("2026-01-10T12:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-01-29T08:30:00Z"))
+                .build();
     }
 }

--- a/application/src/main/java/com/sitionix/bffssox/usecase/ActivateAgentImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/ActivateAgentImpl.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.Agent;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActivateAgentImpl implements ActivateAgent {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public Agent execute(final UUID agentId) {
+        return this.agentClient.activateAgent(agentId);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/ArchiveAgentImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/ArchiveAgentImpl.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.Agent;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArchiveAgentImpl implements ArchiveAgent {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public Agent execute(final UUID agentId) {
+        return this.agentClient.archiveAgent(agentId);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/ActivateAgentImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/ActivateAgentImplTest.java
@@ -1,0 +1,51 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.Agent;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActivateAgentImplTest {
+
+    private ActivateAgent activateAgent;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.activateAgent = new ActivateAgentImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenAgentId_whenExecute_thenReturnAgent() {
+        //given
+        final UUID agentId = UUID.fromString("00000000-0000-0000-0000-000000000007");
+        final Agent response = mock(Agent.class);
+        when(this.agentClient.activateAgent(agentId)).thenReturn(response);
+
+        //when
+        final Agent actual = this.activateAgent.execute(agentId);
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentClient).activateAgent(agentId);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/ArchiveAgentImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/ArchiveAgentImplTest.java
@@ -1,0 +1,51 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.Agent;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveAgentImplTest {
+
+    private ArchiveAgent archiveAgent;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.archiveAgent = new ArchiveAgentImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenAgentId_whenExecute_thenReturnAgent() {
+        //given
+        final UUID agentId = UUID.fromString("00000000-0000-0000-0000-000000000008");
+        final Agent response = mock(Agent.class);
+        when(this.agentClient.archiveAgent(agentId)).thenReturn(response);
+
+        //when
+        final Agent actual = this.archiveAgent.execute(agentId);
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentClient).archiveAgent(agentId);
+    }
+}

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentLifecycleControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentLifecycleControllerIT.java
@@ -1,0 +1,194 @@
+package com.sitionix.bffssox.it.tests;
+
+import com.sitionix.bffssox.it.preparation.AuthJwksDataPreparation;
+import com.sitionix.bffssox.it.utils.MockMvcEndpoint;
+import com.sitionix.bffssox.it.utils.WireMockEndpoint;
+import com.sitionix.forgeit.core.test.IntegrationTest;
+import com.sitionix.forgeit.mockmvc.api.PathParams;
+import com.sitionix.forgeit.wiremock.api.WireMockPathParams;
+import com.sitionix.forgeit.wiremock.internal.domain.RequestBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+@IntegrationTest(preparations = AuthJwksDataPreparation.class)
+class AgentLifecycleControllerIT {
+
+    @Autowired
+    private TestManager testManager;
+
+    @Test
+    @DisplayName("given valid user token when activate agent then return active agent")
+    void givenValidUserToken_whenActivateAgent_thenReturnActiveAgent() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_ACTIVATE_AGENT)
+                .pathPattern(WireMockPathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ACTIVATE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
+    @DisplayName("given valid user token when archive agent then return archived agent")
+    void givenValidUserToken_whenArchiveAgent_thenReturnArchivedAgent() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_ARCHIVE_AGENT)
+                .pathPattern(WireMockPathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ARCHIVE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
+    @DisplayName("given invalid agent id when activate agent then return bad request")
+    void givenInvalidAgentId_whenActivateAgent_thenReturnBadRequest() {
+        //given
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ACTIVATE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "not-a-valid-id"))
+                .applyDefault(context -> context.expectStatus(HttpStatus.BAD_REQUEST.value())
+                        .expectResponse("responseDefaultActivateAgentInvalidAgentId.json"))
+                .assertDefault();
+    }
+
+    @Test
+    @DisplayName("given missing token when activate agent then return unauthorized and do not call upstream")
+    void givenMissingToken_whenActivateAgent_thenReturnUnauthorizedAndDoNotCallUpstream() {
+        //given
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ACTIVATE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .token(null)
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
+                        .expectResponse("responseDefaultGetSitesUnauthorized.json"))
+                .assertDefault();
+    }
+
+    @Test
+    @DisplayName("given missing token when archive agent then return unauthorized")
+    void givenMissingToken_whenArchiveAgent_thenReturnUnauthorized() {
+        //given
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ARCHIVE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .token(null)
+                .applyDefault(context -> context.expectStatus(HttpStatus.UNAUTHORIZED.value())
+                        .expectResponse("responseDefaultGetSitesUnauthorized.json"))
+                .assertDefault();
+    }
+
+    @Test
+    @DisplayName("given invalid agent id when archive agent then return bad request")
+    void givenInvalidAgentId_whenArchiveAgent_thenReturnBadRequest() {
+        //given
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ARCHIVE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "not-a-valid-id"))
+                .applyDefault(context -> context.expectStatus(HttpStatus.BAD_REQUEST.value())
+                        .expectResponse("responseDefaultActivateAgentInvalidAgentId.json"))
+                .assertDefault();
+    }
+
+    @Test
+    @DisplayName("given invalid transition conflict from upstream when activate agent then return conflict with body")
+    void givenInvalidTransitionConflictFromUpstream_whenActivateAgent_thenReturnConflictWithBody() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_ACTIVATE_AGENT)
+                .pathPattern(WireMockPathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .applyDefault(context -> context.responseStatus(HttpStatus.CONFLICT.value())
+                        .responseBody("responseDefaultMappingActivateAgentInvalidTransitionConflict.json"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ACTIVATE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .applyDefault(context -> context.expectStatus(HttpStatus.CONFLICT.value())
+                        .expectResponse("responseDefaultActivateAgentInvalidTransitionConflict.json"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
+    @DisplayName("given invalid transition conflict from upstream when archive agent then return conflict with body")
+    void givenInvalidTransitionConflictFromUpstream_whenArchiveAgent_thenReturnConflictWithBody() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_ARCHIVE_AGENT)
+                .pathPattern(WireMockPathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .applyDefault(context -> context.responseStatus(HttpStatus.CONFLICT.value())
+                        .responseBody("responseDefaultMappingArchiveAgentInvalidTransitionConflict.json"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ARCHIVE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .applyDefault(context -> context.expectStatus(HttpStatus.CONFLICT.value())
+                        .expectResponse("responseDefaultArchiveAgentInvalidTransitionConflict.json"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
+    @DisplayName("given upstream not found when archive agent then return not found with body")
+    void givenUpstreamNotFound_whenArchiveAgent_thenReturnNotFoundWithBody() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_ARCHIVE_AGENT)
+                .pathPattern(WireMockPathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .applyDefault(context -> context.responseStatus(HttpStatus.NOT_FOUND.value())
+                        .responseBody("responseDefaultMappingArchiveAgentNotFound.json"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_ARCHIVE_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .applyDefault(context -> context.expectStatus(HttpStatus.NOT_FOUND.value())
+                        .expectResponse("responseDefaultArchiveAgentNotFound.json"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+}

--- a/boot/src/test/java/com/sitionix/bffssox/it/utils/MockMvcEndpoint.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/utils/MockMvcEndpoint.java
@@ -6,6 +6,7 @@ import com.app_afesox.bffssox.api_first.dto.CreateSiteRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateSiteResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.LoginRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.LoginResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.SiteOverviewDTO;
 import com.app_afesox.bffssox.api_first.dto.RefreshAccessTokenRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.RefreshAccessTokenResponseDTO;
@@ -91,5 +92,23 @@ public class MockMvcEndpoint {
                     Void.class,
                     SiteOverviewDTO.class,
                     (MockmvcDefault) context -> context.expectStatus(HttpStatus.OK.value()),
+                    ItUserTokens.USER_JWT);
+
+    public static final Endpoint<Void, AgentDTO> POST_ACTIVATE_AGENT =
+            Endpoint.createContract("/api/v1/agents/{agentId}/activate",
+                    HttpMethod.POST,
+                    Void.class,
+                    AgentDTO.class,
+                    (MockmvcDefault) context -> context.expectStatus(HttpStatus.OK.value())
+                            .expectResponse("responseDefaultActivateAgentWithHappyPath.json"),
+                    ItUserTokens.USER_JWT);
+
+    public static final Endpoint<Void, AgentDTO> POST_ARCHIVE_AGENT =
+            Endpoint.createContract("/api/v1/agents/{agentId}/archive",
+                    HttpMethod.POST,
+                    Void.class,
+                    AgentDTO.class,
+                    (MockmvcDefault) context -> context.expectStatus(HttpStatus.OK.value())
+                            .expectResponse("responseDefaultArchiveAgentWithHappyPath.json"),
                     ItUserTokens.USER_JWT);
 }

--- a/boot/src/test/java/com/sitionix/bffssox/it/utils/WireMockEndpoint.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/utils/WireMockEndpoint.java
@@ -4,6 +4,7 @@ import com.app_afesox.athssox.client.dto.EmailVerificationDTO;
 import com.app_afesox.athssox.client.dto.EmailVerificationResponseDTO;
 import com.app_afesox.athssox.client.dto.LoginRequestDTO;
 import com.app_afesox.athssox.client.dto.LoginResponseDTO;
+import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.athssox.client.dto.RefreshAccessTokenRequestDTO;
 import com.app_afesox.athssox.client.dto.RefreshAccessTokenResponseDTO;
 import com.app_afesox.athssox.client.dto.ResendEmailVerificationResponseDTO;
@@ -129,6 +130,30 @@ public class WireMockEndpoint {
                         context.header("X-Forge-User-Sub", Parameter.equalTo("it-user-123"))
                                 .header("Authorization", Parameter.matches("Bearer\\s+.+"))
                                 .responseBody("responseDefaultMappingGetSiteOverviewWithHappyPath.json")
+                                .responseStatus(200);
+                    });
+
+    public static final Endpoint<Void, AgentDTO> POST_ACTIVATE_AGENT =
+            Endpoint.createContract("/atmssox/api/v1/agents/{agentId}/activate",
+                    HttpMethod.POST,
+                    Void.class,
+                    AgentDTO.class,
+                    (WiremockDefault) context -> {
+                        context.header("X-Forge-User-Sub", Parameter.equalTo("it-user-123"))
+                                .header("Authorization", Parameter.matches("Bearer\\s+.+"))
+                                .responseBody("responseDefaultMappingActivateAgentWithHappyPath.json")
+                                .responseStatus(200);
+                    });
+
+    public static final Endpoint<Void, AgentDTO> POST_ARCHIVE_AGENT =
+            Endpoint.createContract("/atmssox/api/v1/agents/{agentId}/archive",
+                    HttpMethod.POST,
+                    Void.class,
+                    AgentDTO.class,
+                    (WiremockDefault) context -> {
+                        context.header("X-Forge-User-Sub", Parameter.equalTo("it-user-123"))
+                                .header("Authorization", Parameter.matches("Bearer\\s+.+"))
+                                .responseBody("responseDefaultMappingArchiveAgentWithHappyPath.json")
                                 .responseStatus(200);
                     });
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultActivateAgentInvalidAgentId.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultActivateAgentInvalidAgentId.json
@@ -1,0 +1,5 @@
+{
+  "code": 400,
+  "title": "Bad Request",
+  "details": "Invalid agentId"
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultActivateAgentInvalidTransitionConflict.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultActivateAgentInvalidTransitionConflict.json
@@ -1,0 +1,5 @@
+{
+  "code": 409,
+  "title": "Conflict",
+  "details": "Agent transition ACTIVE -> ACTIVE is not allowed"
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultActivateAgentWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultActivateAgentWithHappyPath.json
@@ -1,0 +1,8 @@
+{
+  "id": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "name": "Agent lifecycle",
+  "description": "Lifecycle forwarding happy path",
+  "status": "ACTIVE",
+  "createdAt": "2026-03-10T12:30:00Z",
+  "updatedAt": "2026-03-10T12:35:00Z"
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultArchiveAgentInvalidTransitionConflict.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultArchiveAgentInvalidTransitionConflict.json
@@ -1,0 +1,5 @@
+{
+  "code": 409,
+  "title": "Conflict",
+  "details": "Agent transition ARCHIVED -> ARCHIVED is not allowed"
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultArchiveAgentNotFound.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultArchiveAgentNotFound.json
@@ -1,0 +1,5 @@
+{
+  "code": 404,
+  "title": "Not Found",
+  "details": "Agent not found"
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultArchiveAgentWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultArchiveAgentWithHappyPath.json
@@ -1,0 +1,8 @@
+{
+  "id": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "name": "Agent lifecycle",
+  "description": "Lifecycle forwarding happy path",
+  "status": "ARCHIVED",
+  "createdAt": "2026-03-10T12:30:00Z",
+  "updatedAt": "2026-03-10T12:40:00Z"
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingActivateAgentInvalidTransitionConflict.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingActivateAgentInvalidTransitionConflict.json
@@ -1,0 +1,5 @@
+{
+  "code": 409,
+  "title": "Conflict",
+  "details": "Agent transition ACTIVE -> ACTIVE is not allowed"
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingActivateAgentWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingActivateAgentWithHappyPath.json
@@ -1,0 +1,8 @@
+{
+  "id": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "name": "Agent lifecycle",
+  "description": "Lifecycle forwarding happy path",
+  "status": "ACTIVE",
+  "createdAt": "2026-03-10T12:30:00Z",
+  "updatedAt": "2026-03-10T12:35:00Z"
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingArchiveAgentInvalidTransitionConflict.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingArchiveAgentInvalidTransitionConflict.json
@@ -1,0 +1,5 @@
+{
+  "code": 409,
+  "title": "Conflict",
+  "details": "Agent transition ARCHIVED -> ARCHIVED is not allowed"
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingArchiveAgentNotFound.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingArchiveAgentNotFound.json
@@ -1,0 +1,5 @@
+{
+  "code": 404,
+  "title": "Not Found",
+  "details": "Agent not found"
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingArchiveAgentWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingArchiveAgentWithHappyPath.json
@@ -1,0 +1,8 @@
+{
+  "id": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "name": "Agent lifecycle",
+  "description": "Lifecycle forwarding happy path",
+  "status": "ARCHIVED",
+  "createdAt": "2026-03-10T12:30:00Z",
+  "updatedAt": "2026-03-10T12:40:00Z"
+}

--- a/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/EmailVerificationClientMapperTest.java
+++ b/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/EmailVerificationClientMapperTest.java
@@ -51,6 +51,53 @@ class EmailVerificationClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final EmailVerificationRequest request = null;
+        final EmailVerificationResponseDTO responseDTO = null;
+
+        //when
+        final EmailVerificationDTO actualRequest = this.mapper.asEmailVerificationDto(request);
+        final EmailVerificationResponse actualResponse = this.mapper.asEmailVerificationResponse(responseDTO);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenPendingEmailVerifyStatus_whenMap_thenReturnPendingEmailVerifyStatus() {
+        //given
+        final EmailVerificationResponseDTO responseDTO = new EmailVerificationResponseDTO()
+                .message("m")
+                .status(EmailVerificationResponseDTO.StatusEnum.PENDING_EMAIL_VERIFY);
+
+        //when
+        final EmailVerificationResponse actual = this.mapper.asEmailVerificationResponse(responseDTO);
+
+        //then
+        assertThat(actual.getStatus()).isEqualTo(EmailVerificationStatus.PENDING_EMAIL_VERIFY);
+    }
+
+    @Test
+    void givenAllStatuses_whenMap_thenReturnMappedStatuses() {
+        //given
+        final String message = "m";
+
+        //when
+        for (final EmailVerificationResponseDTO.StatusEnum statusEnum : EmailVerificationResponseDTO.StatusEnum.values()) {
+            final EmailVerificationResponseDTO responseDTO = new EmailVerificationResponseDTO()
+                    .message(message)
+                    .status(statusEnum);
+            final EmailVerificationResponse actual = this.mapper.asEmailVerificationResponse(responseDTO);
+            assertThat(actual.getStatus().name()).isEqualTo(statusEnum.name());
+        }
+
+        //then
+        assertThat(EmailVerificationResponseDTO.StatusEnum.values().length).isGreaterThan(0);
+    }
+
     private EmailVerificationDTO emailVerificationDTO(final UUID uuid) {
         return new EmailVerificationDTO()
                 .token("token")

--- a/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/LoginUserClientMapperTest.java
+++ b/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/LoginUserClientMapperTest.java
@@ -50,6 +50,21 @@ class LoginUserClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final LoginRequest loginRequest = null;
+        final LoginResponseDTO loginResponseDTO = null;
+
+        //when
+        final LoginRequestDTO actualRequest = this.mapper.asLoginRequestDto(loginRequest);
+        final LoginResponse actualResponse = this.mapper.asLoginResponse(loginResponseDTO);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
     private LoginRequestDTO loginRequestDTO(final UUID uuid) {
         return new LoginRequestDTO()
                 .email("email")

--- a/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/RefreshAccessTokenClientMapperTest.java
+++ b/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/RefreshAccessTokenClientMapperTest.java
@@ -47,6 +47,21 @@ class RefreshAccessTokenClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final RefreshAccessTokenRequest request = null;
+        final RefreshAccessTokenResponseDTO responseDTO = null;
+
+        //when
+        final RefreshAccessTokenRequestDTO actualRequest = this.mapper.asRefreshAccessTokenRequestDto(request);
+        final RefreshAccessTokenResponse actualResponse = this.mapper.asRefreshAccessTokenResponse(responseDTO);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
     private RefreshAccessTokenRequestDTO refreshAccessTokenRequestDTO() {
         return new RefreshAccessTokenRequestDTO()
                 .refreshToken("refreshToken")

--- a/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/RegisterUserClientMapperTest.java
+++ b/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/RegisterUserClientMapperTest.java
@@ -52,6 +52,73 @@ class RegisterUserClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final RegisterUserRequest registerUserRequest = null;
+        final ResponseRegisterUserDTO responseRegisterUserDTO = null;
+
+        //when
+        final RegisterUserDTO actualRequest = this.mapper.asRegisterUserDto(registerUserRequest);
+        final RegisterUserResponse actualResponse = this.mapper.asRegisterUserResponse(responseRegisterUserDTO);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenAllRoleAndStatusVariants_whenMap_thenReturnMappedVariants() {
+        //given
+        final RegisterUserRequest registerUserRequest = RegisterUserRequest.builder()
+                .email("e")
+                .password("p")
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .role(RegisterUserRole.SUPER_ADMIN)
+                .build();
+        final ResponseRegisterUserDTO responseRegisterUserDTO = new ResponseRegisterUserDTO()
+                .message("m")
+                .status(ResponseRegisterUserDTO.StatusEnum.BANNED)
+                .userId(10L);
+
+        //when
+        final RegisterUserDTO actualRequest = this.mapper.asRegisterUserDto(registerUserRequest);
+        final RegisterUserResponse actualResponse = this.mapper.asRegisterUserResponse(responseRegisterUserDTO);
+
+        //then
+        assertThat(actualRequest.getRole()).isEqualTo(RegisterUserDTO.RoleEnum.SUPER_ADMIN);
+        assertThat(actualResponse.getStatus()).isEqualTo(RegisterUserStatus.BANNED);
+    }
+
+    @Test
+    void givenAllEnums_whenMap_thenReturnMappedEnums() {
+        //given
+        final UUID siteId = UUID.fromString("00000000-0000-0000-0000-000000000006");
+
+        //when
+        for (final RegisterUserRole role : RegisterUserRole.values()) {
+            final RegisterUserRequest request = RegisterUserRequest.builder()
+                    .email("e")
+                    .password("p")
+                    .siteId(siteId)
+                    .role(role)
+                    .build();
+            final RegisterUserDTO actualRequest = this.mapper.asRegisterUserDto(request);
+            assertThat(actualRequest.getRole().name()).isEqualTo(role.name());
+        }
+        for (final ResponseRegisterUserDTO.StatusEnum statusEnum : ResponseRegisterUserDTO.StatusEnum.values()) {
+            final ResponseRegisterUserDTO responseDTO = new ResponseRegisterUserDTO()
+                    .message("m")
+                    .status(statusEnum)
+                    .userId(10L);
+            final RegisterUserResponse actualResponse = this.mapper.asRegisterUserResponse(responseDTO);
+            assertThat(actualResponse.getStatus().name()).isEqualTo(statusEnum.name());
+        }
+
+        //then
+        assertThat(ResponseRegisterUserDTO.StatusEnum.values().length).isGreaterThan(0);
+    }
+
     private RegisterUserDTO registerUserDTO(final UUID uuid) {
         return new RegisterUserDTO()
                 .email("email")

--- a/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/ResendEmailVerificationClientMapperTest.java
+++ b/clients/client-athssox/src/test/java/com/sitionix/bffssox/mapper/ResendEmailVerificationClientMapperTest.java
@@ -32,6 +32,18 @@ class ResendEmailVerificationClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullResponseDto_whenAsResendEmailVerificationResponse_thenReturnNull() {
+        //given
+        final ResendEmailVerificationResponseDTO given = null;
+
+        //when
+        final ResendEmailVerificationResponse actual = this.mapper.asResendEmailVerificationResponse(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
     private ResendEmailVerificationResponseDTO resendEmailVerificationResponseDTO() {
         return new ResendEmailVerificationResponseDTO()
                 .message("message");

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.5</atmssox.api.version>
+        <atmssox.api.version>0.0.6</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-113-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -54,6 +54,22 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     }
 
     @Override
+    public Agent activateAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentApi.activateAgent(agentId)
+        );
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    @Override
+    public Agent archiveAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentApi.archiveAgent(agentId)
+        );
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    @Override
     public Agent patchAgent(final UUID agentId, final PatchAgentRequest request) {
         final PatchAgentRequestDTO requestDTO = this.patchAgentClientMapper.asPatchAgentRequestDto(request);
         final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -171,4 +171,52 @@ class AgentClientImplTest {
         verify(this.agentApi).patchAgent(givenAgentId, requestDTO);
         verify(this.agentClientMapper).asAgent(responseDTO);
     }
+
+    @Test
+    void givenAgentId_whenActivateAgent_thenReturnAgent() {
+        //given
+        final UUID givenAgentId = UUID.fromString("88e2673a-273a-4cf4-a94f-96f4df311ea9");
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final Agent expected = mock(Agent.class);
+
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.activateAgent(givenAgentId)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+
+        //when
+        final Agent actual = this.agentClient.activateAgent(givenAgentId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).activateAgent(givenAgentId);
+        verify(this.agentClientMapper).asAgent(responseDTO);
+    }
+
+    @Test
+    void givenAgentId_whenArchiveAgent_thenReturnAgent() {
+        //given
+        final UUID givenAgentId = UUID.fromString("f8f58985-8fa8-4412-8f1e-7955f0f8f85e");
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final Agent expected = mock(Agent.class);
+
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.archiveAgent(givenAgentId)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+
+        //when
+        final Agent actual = this.agentClient.archiveAgent(givenAgentId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).archiveAgent(givenAgentId);
+        verify(this.agentClientMapper).asAgent(responseDTO);
+    }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/AgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/AgentClientMapperTest.java
@@ -1,0 +1,103 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.atmssox.client.dto.AgentDTO;
+import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.AgentStatus;
+import com.sitionix.bffssox.domain.AgentsResponse;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class AgentClientMapperTest {
+
+    private AgentClientMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new AgentClientMapperImpl();
+    }
+
+    @Test
+    void givenAgentDto_whenAsAgent_thenReturnAgent() {
+        //given
+        final AgentDTO given = this.agentDto();
+        final Agent expected = this.agent();
+
+        //when
+        final Agent actual = this.mapper.asAgent(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenAgentsResponseDto_whenAsAgentsResponse_thenReturnAgentsResponse() {
+        //given
+        final AgentsResponseDTO given = AgentsResponseDTO.builder()
+                .items(List.of(this.agentDto()))
+                .build();
+        final AgentsResponse expected = AgentsResponse.builder()
+                .items(List.of(this.agent()))
+                .build();
+
+        //when
+        final AgentsResponse actual = this.mapper.asAgentsResponse(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullAgentDto_whenAsAgent_thenReturnNull() {
+        //given
+        final AgentDTO given = null;
+
+        //when
+        final Agent actual = this.mapper.asAgent(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenNullAgentsResponseDto_whenAsAgentsResponse_thenReturnNull() {
+        //given
+        final AgentsResponseDTO given = null;
+
+        //when
+        final AgentsResponse actual = this.mapper.asAgentsResponse(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    private AgentDTO agentDto() {
+        return AgentDTO.builder()
+                .id(UUID.fromString("9df8ca36-d8c8-4703-9f8c-c8d50b5d4794"))
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .status(AgentDTO.StatusEnum.ARCHIVED)
+                .createdAt(OffsetDateTime.parse("2026-04-10T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-10T10:01:00Z"))
+                .build();
+    }
+
+    private Agent agent() {
+        return Agent.builder()
+                .id("9df8ca36-d8c8-4703-9f8c-c8d50b5d4794")
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .status(AgentStatus.ARCHIVED)
+                .createdAt(OffsetDateTime.parse("2026-04-10T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-10T10:01:00Z"))
+                .build();
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/CreateAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/CreateAgentClientMapperTest.java
@@ -1,0 +1,52 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
+import com.sitionix.bffssox.domain.CreateAgentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class CreateAgentClientMapperTest {
+
+    private CreateAgentClientMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new CreateAgentClientMapperImpl();
+    }
+
+    @Test
+    void givenCreateAgentRequest_whenAsCreateAgentRequestDto_thenReturnCreateAgentRequestDto() {
+        //given
+        final CreateAgentRequest given = CreateAgentRequest.builder()
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .build();
+        final CreateAgentRequestDTO expected = CreateAgentRequestDTO.builder()
+                .name("Architecture Reviewer")
+                .description("Checks architecture decisions")
+                .build();
+
+        //when
+        final CreateAgentRequestDTO actual = this.mapper.asCreateAgentRequestDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullCreateAgentRequest_whenAsCreateAgentRequestDto_thenReturnNull() {
+        //given
+        final CreateAgentRequest given = null;
+
+        //when
+        final CreateAgentRequestDTO actual = this.mapper.asCreateAgentRequestDto(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/PatchAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/PatchAgentClientMapperTest.java
@@ -1,0 +1,52 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class PatchAgentClientMapperTest {
+
+    private PatchAgentClientMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new PatchAgentClientMapperImpl();
+    }
+
+    @Test
+    void givenPatchAgentRequest_whenAsPatchAgentRequestDto_thenReturnPatchAgentRequestDto() {
+        //given
+        final PatchAgentRequest given = PatchAgentRequest.builder()
+                .name("Updated Architecture Reviewer")
+                .description("Updated description")
+                .build();
+        final PatchAgentRequestDTO expected = PatchAgentRequestDTO.builder()
+                .name("Updated Architecture Reviewer")
+                .description("Updated description")
+                .build();
+
+        //when
+        final PatchAgentRequestDTO actual = this.mapper.asPatchAgentRequestDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullPatchAgentRequest_whenAsPatchAgentRequestDto_thenReturnNull() {
+        //given
+        final PatchAgentRequest given = null;
+
+        //when
+        final PatchAgentRequestDTO actual = this.mapper.asPatchAgentRequestDto(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+}

--- a/clients/client-stsssox/src/test/java/com/sitionix/bffssox/mapper/CreateSiteClientMapperTest.java
+++ b/clients/client-stsssox/src/test/java/com/sitionix/bffssox/mapper/CreateSiteClientMapperTest.java
@@ -52,6 +52,81 @@ class CreateSiteClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenNullInputs_whenMap_thenReturnNull() {
+        //given
+        final CreateSiteRequest createSiteRequest = null;
+        final CreateSiteResponseDTO createSiteResponseDTO = null;
+
+        //when
+        final CreateSiteRequestDTO actualRequest = this.mapper.asCreateSiteRequestDto(createSiteRequest);
+        final CreateSiteResponse actualResponse = this.mapper.asCreateSiteResponse(createSiteResponseDTO);
+
+        //then
+        assertThat(actualRequest).isNull();
+        assertThat(actualResponse).isNull();
+    }
+
+    @Test
+    void givenOtherTypeAndArchivedStatus_whenMap_thenReturnMappedEnums() {
+        //given
+        final CreateSiteRequest createSiteRequest = CreateSiteRequest.builder()
+                .name("My site")
+                .type(SiteType.OTHER)
+                .description("d")
+                .template(SiteTemplate.BLANK)
+                .build();
+        final CreateSiteResponseDTO createSiteResponseDTO = new CreateSiteResponseDTO()
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .name("My site")
+                .status(CreateSiteResponseDTO.StatusEnum.ARCHIVED)
+                .createdAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"));
+
+        //when
+        final CreateSiteRequestDTO actualRequest = this.mapper.asCreateSiteRequestDto(createSiteRequest);
+        final CreateSiteResponse actualResponse = this.mapper.asCreateSiteResponse(createSiteResponseDTO);
+
+        //then
+        assertThat(actualRequest.getType()).isEqualTo(CreateSiteRequestDTO.TypeEnum.OTHER);
+        assertThat(actualResponse.getStatus()).isEqualTo(SiteStatus.ARCHIVED);
+    }
+
+    @Test
+    void givenAllEnums_whenMap_thenReturnMappedEnums() {
+        //given
+        final CreateSiteRequest baseRequest = CreateSiteRequest.builder()
+                .name("n")
+                .description("d")
+                .template(SiteTemplate.BLANK)
+                .build();
+
+        //when
+        for (final SiteType siteType : SiteType.values()) {
+            final CreateSiteRequest request = CreateSiteRequest.builder()
+                    .name(baseRequest.getName())
+                    .description(baseRequest.getDescription())
+                    .template(baseRequest.getTemplate())
+                    .type(siteType)
+                    .build();
+            final CreateSiteRequestDTO actualRequest = this.mapper.asCreateSiteRequestDto(request);
+            assertThat(actualRequest.getType().name()).isEqualTo(siteType.name());
+        }
+        for (final CreateSiteResponseDTO.StatusEnum statusEnum : CreateSiteResponseDTO.StatusEnum.values()) {
+            final CreateSiteResponseDTO responseDTO = new CreateSiteResponseDTO()
+                    .siteId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                    .name("n")
+                    .status(statusEnum)
+                    .createdAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"))
+                    .updatedAt(OffsetDateTime.parse("2026-02-17T10:00:00Z"));
+            final CreateSiteResponse actualResponse = this.mapper.asCreateSiteResponse(responseDTO);
+            assertThat(actualResponse.getStatus().name()).isEqualTo(statusEnum.name());
+        }
+
+        //then
+        assertThat(CreateSiteRequestDTO.TemplateEnum.BLANK.name()).isEqualTo(SiteTemplate.BLANK.name());
+    }
+
     private CreateSiteRequest createSiteRequest() {
         return CreateSiteRequest.builder()
                 .name("My portfolio")

--- a/clients/client-wagssox/src/test/java/com/sitionix/bffssox/mapper/SiteOverviewClientMapperTest.java
+++ b/clients/client-wagssox/src/test/java/com/sitionix/bffssox/mapper/SiteOverviewClientMapperTest.java
@@ -36,6 +36,75 @@ class SiteOverviewClientMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenSiteOverviewDtoWithArchivedStatusAndOtherType_whenAsSiteOverview_thenReturnMappedEnums() {
+        //given
+        final SiteOverviewDTO responseDTO = new SiteOverviewDTO()
+                .siteId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .name("n")
+                .status(SiteOverviewDTO.StatusEnum.ARCHIVED)
+                .type(SiteOverviewDTO.TypeEnum.OTHER)
+                .description("d")
+                .createdAt(OffsetDateTime.parse("2026-01-10T12:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-01-29T08:30:00Z"));
+
+        //when
+        final SiteOverview actual = this.mapper.asSiteOverview(responseDTO);
+
+        //then
+        assertThat(actual.getStatus()).isEqualTo(SiteStatus.ARCHIVED);
+        assertThat(actual.getType()).isEqualTo(SiteType.OTHER);
+    }
+
+    @Test
+    void givenNullSiteOverviewDto_whenAsSiteOverview_thenReturnNull() {
+        //given
+        final SiteOverviewDTO responseDTO = null;
+
+        //when
+        final SiteOverview actual = this.mapper.asSiteOverview(responseDTO);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenAllEnums_whenAsSiteOverview_thenReturnMappedEnums() {
+        //given
+        final UUID siteId = UUID.fromString("00000000-0000-0000-0000-000000000004");
+        final OffsetDateTime createdAt = OffsetDateTime.parse("2026-01-10T12:00:00Z");
+        final OffsetDateTime updatedAt = OffsetDateTime.parse("2026-01-29T08:30:00Z");
+
+        //when
+        for (final SiteOverviewDTO.StatusEnum statusEnum : SiteOverviewDTO.StatusEnum.values()) {
+            final SiteOverviewDTO siteOverviewDTO = new SiteOverviewDTO()
+                    .siteId(siteId)
+                    .name("n")
+                    .status(statusEnum)
+                    .type(SiteOverviewDTO.TypeEnum.PORTFOLIO)
+                    .description("d")
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt);
+            final SiteOverview actual = this.mapper.asSiteOverview(siteOverviewDTO);
+            assertThat(actual.getStatus().name()).isEqualTo(statusEnum.name());
+        }
+        for (final SiteOverviewDTO.TypeEnum typeEnum : SiteOverviewDTO.TypeEnum.values()) {
+            final SiteOverviewDTO siteOverviewDTO = new SiteOverviewDTO()
+                    .siteId(siteId)
+                    .name("n")
+                    .status(SiteOverviewDTO.StatusEnum.DRAFT)
+                    .type(typeEnum)
+                    .description("d")
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt);
+            final SiteOverview actual = this.mapper.asSiteOverview(siteOverviewDTO);
+            assertThat(actual.getType().name()).isEqualTo(typeEnum.name());
+        }
+
+        //then
+        assertThat(SiteOverviewDTO.TypeEnum.values().length).isGreaterThan(0);
+    }
+
     private SiteOverviewDTO getSiteOverviewDto() {
         return new SiteOverviewDTO()
                 .siteId(UUID.fromString("c9b1f3f4-12c7-11ec-82a8-0242ac130003"))

--- a/clients/client-wagssox/src/test/java/com/sitionix/bffssox/mapper/WorkspaceSiteClientMapperTest.java
+++ b/clients/client-wagssox/src/test/java/com/sitionix/bffssox/mapper/WorkspaceSiteClientMapperTest.java
@@ -7,6 +7,7 @@ import com.sitionix.bffssox.domain.SiteType;
 import com.sitionix.bffssox.domain.WorkspaceSiteCard;
 import com.sitionix.bffssox.domain.WorkspaceSitesPage;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,6 +131,29 @@ class WorkspaceSiteClientMapperTest {
 
         //then
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenWorkspaceSitesPageDtoWithNullItem_whenAsWorkspaceSitesPage_thenKeepNullItem() {
+        //given
+        final WorkspaceSitesPageDTO responseDTO = this.workspaceSitesPageDto(
+                Arrays.asList(this.workspaceSiteCardDto(
+                        "00000000-0000-0000-0000-000000000001",
+                        WorkspaceSiteCardDTO.StatusEnum.DRAFT,
+                        WorkspaceSiteCardDTO.TypeEnum.PORTFOLIO,
+                        null
+                ), null),
+                0,
+                20,
+                true
+        );
+
+        //when
+        final WorkspaceSitesPage actual = this.mapper.asWorkspaceSitesPage(responseDTO);
+
+        //then
+        assertThat(actual.getItems()).hasSize(2);
+        assertThat(actual.getItems().get(1)).isNull();
     }
 
     @Test

--- a/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
+++ b/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
@@ -35,6 +35,22 @@ public interface AgentClient {
     Agent getAgent(UUID agentId);
 
     /**
+     * Activates one automation agent.
+     *
+     * @param agentId unique agent identifier.
+     * @return updated agent.
+     */
+    Agent activateAgent(UUID agentId);
+
+    /**
+     * Archives one automation agent.
+     *
+     * @param agentId unique agent identifier.
+     * @return updated agent.
+     */
+    Agent archiveAgent(UUID agentId);
+
+    /**
      * Applies partial identity update for one automation agent.
      *
      * @param agentId unique agent identifier.

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentStatus.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentStatus.java
@@ -1,5 +1,7 @@
 package com.sitionix.bffssox.domain;
 
 public enum AgentStatus {
-    DRAFT
+    DRAFT,
+    ACTIVE,
+    ARCHIVED
 }

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/ActivateAgent.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/ActivateAgent.java
@@ -1,0 +1,18 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.Agent;
+import java.util.UUID;
+
+/**
+ * Use case for activating one automation agent.
+ */
+public interface ActivateAgent {
+
+    /**
+     * Activates one automation agent.
+     *
+     * @param agentId agent identifier.
+     * @return updated agent.
+     */
+    Agent execute(UUID agentId);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/ArchiveAgent.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/ArchiveAgent.java
@@ -1,0 +1,18 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.Agent;
+import java.util.UUID;
+
+/**
+ * Use case for archiving one automation agent.
+ */
+public interface ArchiveAgent {
+
+    /**
+     * Archives one automation agent.
+     *
+     * @param agentId agent identifier.
+     * @return updated agent.
+     */
+    Agent execute(UUID agentId);
+}


### PR DESCRIPTION
## Summary
- expose lifecycle endpoints in BFF AgentController
- forward activate/archive actions to automationservice-sox client
- align BFF and ATMS unstable contract dependencies for lifecycle endpoints and status enum