### PR TITLE
[SITIONIX-116] - add agent chat v1 bff endpoint

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.25</bffssox.api.version>
+        <bffssox.api.version>0.0.26</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-116-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
@@ -3,16 +3,21 @@ package com.sitionix.bffssox.controller;
 import com.app_afesox.bffssox.api_first.api.AgentApi;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
+import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.ActivateAgent;
 import com.sitionix.bffssox.usecase.ArchiveAgent;
+import com.sitionix.bffssox.usecase.ChatAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.DeleteAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
@@ -40,6 +45,10 @@ public class AgentController implements AgentApi {
     private final PatchAgentApiMapper patchAgentApiMapper;
 
     private final PatchAgent patchAgent;
+
+    private final ChatAgentApiMapper chatAgentApiMapper;
+
+    private final ChatAgent chatAgent;
 
     private final GetAgents getAgents;
 
@@ -102,6 +111,13 @@ public class AgentController implements AgentApi {
     public ResponseEntity<AgentDTO> deleteAgent(final UUID agentId) {
         final Agent response = this.deleteAgent.execute(agentId);
         return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ChatAgentResponseDTO> chatAgent(final UUID agentId, @Valid final ChatAgentRequestDTO chatAgentRequestDTO) {
+        final ChatAgentResponse response = this.chatAgent.execute(agentId, this.chatAgentApiMapper.asChatAgentRequest(chatAgentRequestDTO));
+        return ResponseEntity.ok(this.chatAgentApiMapper.asChatAgentResponseDto(response));
     }
 
     @Override

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -1,0 +1,15 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ChatAgentApiMapper {
+
+    ChatAgentRequest asChatAgentRequest(ChatAgentRequestDTO src);
+
+    ChatAgentResponseDTO asChatAgentResponseDto(ChatAgentResponse src);
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -2,17 +2,23 @@ package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
+import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.ActivateAgent;
 import com.sitionix.bffssox.usecase.ArchiveAgent;
+import com.sitionix.bffssox.usecase.ChatAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.DeleteAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
@@ -57,6 +63,12 @@ class AgentControllerTest {
     private PatchAgent patchAgent;
 
     @Mock
+    private ChatAgentApiMapper chatAgentApiMapper;
+
+    @Mock
+    private ChatAgent chatAgent;
+
+    @Mock
     private GetAgents getAgents;
 
     @Mock
@@ -82,6 +94,8 @@ class AgentControllerTest {
                 this.createAgent,
                 this.patchAgentApiMapper,
                 this.patchAgent,
+                this.chatAgentApiMapper,
+                this.chatAgent,
                 this.getAgents,
                 this.getAgent,
                 this.activateAgent,
@@ -99,6 +113,8 @@ class AgentControllerTest {
                 this.createAgent,
                 this.patchAgentApiMapper,
                 this.patchAgent,
+                this.chatAgentApiMapper,
+                this.chatAgent,
                 this.getAgents,
                 this.getAgent,
                 this.activateAgent,
@@ -244,5 +260,28 @@ class AgentControllerTest {
         assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
         verify(this.archiveAgent).execute(givenAgentId);
         verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenChatAgentRequestDto_whenChatAgent_thenReturnOkResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        final ChatAgentRequestDTO givenRequestDTO = mock(ChatAgentRequestDTO.class);
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final ChatAgentResponse response = mock(ChatAgentResponse.class);
+        final ChatAgentResponseDTO responseDTO = mock(ChatAgentResponseDTO.class);
+
+        when(this.chatAgentApiMapper.asChatAgentRequest(givenRequestDTO)).thenReturn(request);
+        when(this.chatAgent.execute(givenAgentId, request)).thenReturn(response);
+        when(this.chatAgentApiMapper.asChatAgentResponseDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<ChatAgentResponseDTO> actual = this.agentController.chatAgent(givenAgentId, givenRequestDTO);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.chatAgentApiMapper).asChatAgentRequest(givenRequestDTO);
+        verify(this.chatAgent).execute(givenAgentId, request);
+        verify(this.chatAgentApiMapper).asChatAgentResponseDto(response);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -1,0 +1,81 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class ChatAgentApiMapperTest {
+
+    private ChatAgentApiMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new ChatAgentApiMapperImpl();
+    }
+
+    @Test
+    void givenChatAgentRequestDto_whenAsChatAgentRequest_thenReturnChatAgentRequest() {
+        //given
+        final ChatAgentRequestDTO given = ChatAgentRequestDTO.builder()
+                .message("Explain clean architecture")
+                .build();
+        final ChatAgentRequest expected = ChatAgentRequest.builder()
+                .message("Explain clean architecture")
+                .build();
+
+        //when
+        final ChatAgentRequest actual = this.mapper.asChatAgentRequest(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenChatAgentResponse_whenAsChatAgentResponseDto_thenReturnChatAgentResponseDto() {
+        //given
+        final ChatAgentResponse given = ChatAgentResponse.builder()
+                .reply("Clean architecture separates business rules from frameworks.")
+                .build();
+        final ChatAgentResponseDTO expected = ChatAgentResponseDTO.builder()
+                .reply("Clean architecture separates business rules from frameworks.")
+                .build();
+
+        //when
+        final ChatAgentResponseDTO actual = this.mapper.asChatAgentResponseDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullChatAgentRequestDto_whenAsChatAgentRequest_thenReturnNull() {
+        //given
+        final ChatAgentRequestDTO given = null;
+
+        //when
+        final ChatAgentRequest actual = this.mapper.asChatAgentRequest(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenNullChatAgentResponse_whenAsChatAgentResponseDto_thenReturnNull() {
+        //given
+        final ChatAgentResponse given = null;
+
+        //when
+        final ChatAgentResponseDTO actual = this.mapper.asChatAgentResponseDto(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/ChatAgentImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/ChatAgentImpl.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatAgentImpl implements ChatAgent {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public ChatAgentResponse execute(final UUID agentId, final ChatAgentRequest request) {
+        return this.agentClient.chatAgent(agentId, request);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/ChatAgentImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/ChatAgentImplTest.java
@@ -1,0 +1,53 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatAgentImplTest {
+
+    private ChatAgent chatAgent;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.chatAgent = new ChatAgentImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenChatAgentRequest_whenExecute_thenReturnChatAgentResponse() {
+        //given
+        final UUID agentId = UUID.fromString("2679f99c-1700-41d5-aa20-d58dfdf15a5f");
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final ChatAgentResponse response = mock(ChatAgentResponse.class);
+        when(this.agentClient.chatAgent(agentId, request)).thenReturn(response);
+
+        //when
+        final ChatAgentResponse actual = this.chatAgent.execute(agentId, request);
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentClient).chatAgent(agentId, request);
+    }
+}

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.8</atmssox.api.version>
+        <atmssox.api.version>0.0.9</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-116-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -3,14 +3,19 @@ package com.sitionix.bffssox.client;
 import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import java.util.UUID;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
+import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
 import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +32,8 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     private final AgentClientMapper agentClientMapper;
 
     private final PatchAgentClientMapper patchAgentClientMapper;
+
+    private final ChatAgentClientMapper chatAgentClientMapper;
 
     private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
 
@@ -83,6 +90,15 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
                 () -> this.agentApi.deleteAgent(agentId)
         );
         return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    @Override
+    public ChatAgentResponse chatAgent(final UUID agentId, final ChatAgentRequest request) {
+        final ChatAgentRequestDTO requestDTO = this.chatAgentClientMapper.asChatAgentRequestDto(request);
+        final ChatAgentResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentApi.chatAgent(agentId, requestDTO)
+        );
+        return this.chatAgentClientMapper.asChatAgentResponse(responseDTO);
     }
 
     @Override

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -1,0 +1,15 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ChatAgentClientMapper {
+
+    ChatAgentRequestDTO asChatAgentRequestDto(ChatAgentRequest src);
+
+    ChatAgentResponse asChatAgentResponse(ChatAgentResponseDTO src);
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -10,6 +10,7 @@ import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
+import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
 import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import java.util.UUID;
@@ -46,6 +47,9 @@ class AgentClientImplTest {
     private PatchAgentClientMapper patchAgentClientMapper;
 
     @Mock
+    private ChatAgentClientMapper chatAgentClientMapper;
+
+    @Mock
     private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
 
     @BeforeEach
@@ -55,6 +59,7 @@ class AgentClientImplTest {
                 this.createAgentClientMapper,
                 this.agentClientMapper,
                 this.patchAgentClientMapper,
+                this.chatAgentClientMapper,
                 this.atmssoxClientCallExecutor
         );
     }
@@ -66,6 +71,7 @@ class AgentClientImplTest {
                 this.createAgentClientMapper,
                 this.agentClientMapper,
                 this.patchAgentClientMapper,
+                this.chatAgentClientMapper,
                 this.atmssoxClientCallExecutor
         );
     }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -3,10 +3,14 @@ package com.sitionix.bffssox.client;
 import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
@@ -272,5 +276,33 @@ class AgentClientImplTest {
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentApi).deleteAgent(givenAgentId);
         verify(this.agentClientMapper).asAgent(responseDTO);
+    }
+
+    @Test
+    void givenChatAgentRequest_whenChatAgent_thenReturnChatAgentResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("7ac2f8c1-3d66-4cb4-95d9-27df5c66bf20");
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final ChatAgentRequestDTO requestDTO = mock(ChatAgentRequestDTO.class);
+        final ChatAgentResponseDTO responseDTO = mock(ChatAgentResponseDTO.class);
+        final ChatAgentResponse expected = mock(ChatAgentResponse.class);
+
+        when(this.chatAgentClientMapper.asChatAgentRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<ChatAgentResponseDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.chatAgent(givenAgentId, requestDTO)).thenReturn(responseDTO);
+        when(this.chatAgentClientMapper.asChatAgentResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final ChatAgentResponse actual = this.agentClient.chatAgent(givenAgentId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).chatAgent(givenAgentId, requestDTO);
+        verify(this.chatAgentClientMapper).asChatAgentResponse(responseDTO);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -1,0 +1,81 @@
+package com.sitionix.bffssox.mapper;
+
+import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class ChatAgentClientMapperTest {
+
+    private ChatAgentClientMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mapper = new ChatAgentClientMapperImpl();
+    }
+
+    @Test
+    void givenChatAgentRequest_whenAsChatAgentRequestDto_thenReturnChatAgentRequestDto() {
+        //given
+        final ChatAgentRequest given = ChatAgentRequest.builder()
+                .message("Explain SOLID")
+                .build();
+        final ChatAgentRequestDTO expected = ChatAgentRequestDTO.builder()
+                .message("Explain SOLID")
+                .build();
+
+        //when
+        final ChatAgentRequestDTO actual = this.mapper.asChatAgentRequestDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenChatAgentResponseDto_whenAsChatAgentResponse_thenReturnChatAgentResponse() {
+        //given
+        final ChatAgentResponseDTO given = ChatAgentResponseDTO.builder()
+                .reply("SOLID is a set of design principles.")
+                .build();
+        final ChatAgentResponse expected = ChatAgentResponse.builder()
+                .reply("SOLID is a set of design principles.")
+                .build();
+
+        //when
+        final ChatAgentResponse actual = this.mapper.asChatAgentResponse(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullChatAgentRequest_whenAsChatAgentRequestDto_thenReturnNull() {
+        //given
+        final ChatAgentRequest given = null;
+
+        //when
+        final ChatAgentRequestDTO actual = this.mapper.asChatAgentRequestDto(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenNullChatAgentResponseDto_whenAsChatAgentResponse_thenReturnNull() {
+        //given
+        final ChatAgentResponseDTO given = null;
+
+        //when
+        final ChatAgentResponse actual = this.mapper.asChatAgentResponse(given);
+
+        //then
+        assertThat(actual).isNull();
+    }
+}

--- a/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
+++ b/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
@@ -2,6 +2,8 @@ package com.sitionix.bffssox.client;
 
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import java.util.UUID;
@@ -65,6 +67,15 @@ public interface AgentClient {
      * @return updated agent.
      */
     Agent deleteAgent(UUID agentId);
+
+    /**
+     * Executes one chat request for one automation agent.
+     *
+     * @param agentId unique agent identifier.
+     * @param request chat request payload.
+     * @return assistant reply payload.
+     */
+    ChatAgentResponse chatAgent(UUID agentId, ChatAgentRequest request);
 
     /**
      * Applies partial identity update for one automation agent.

--- a/domain/src/main/java/com/sitionix/bffssox/domain/ChatAgentRequest.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/ChatAgentRequest.java
@@ -1,0 +1,11 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChatAgentRequest {
+
+    private String message;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/ChatAgentResponse.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/ChatAgentResponse.java
@@ -1,0 +1,11 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChatAgentResponse {
+
+    private String reply;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/ChatAgent.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/ChatAgent.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatAgentResponse;
+import java.util.UUID;
+
+/**
+ * Executes one chat request for one automation agent.
+ */
+public interface ChatAgent {
+
+    /**
+     * Executes one request-response chat interaction.
+     *
+     * @param agentId unique agent identifier.
+     * @param request chat request payload.
+     * @return normalized assistant reply payload.
+     */
+    ChatAgentResponse execute(UUID agentId, ChatAgentRequest request);
+}


### PR DESCRIPTION
## Summary
- add POST /api/v1/agents/{agentId}/chat endpoint in BFF
- forward chat request to automationservice client
- add request/response mappers and use case
- wire unstable generated API/client artifacts
