### PR TITLE
[SITIONIX-119] - proxy agent rule lifecycle in bff

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.28</bffssox.api.version>
+        <bffssox.api.version>0.0.29</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-119-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-sitionix-119-unstable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
@@ -4,7 +4,10 @@ import com.app_afesox.bffssox.api_first.api.AgentApi;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
+import com.app_afesox.bffssox.api_first.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
@@ -32,6 +35,7 @@ import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.ActivateAgent;
 import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.ChatAgent;
+import com.sitionix.bffssox.usecase.AcceptAgentRule;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.CreateAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgentRule;
@@ -42,6 +46,7 @@ import com.sitionix.bffssox.usecase.GetAgentConversations;
 import com.sitionix.bffssox.usecase.GetAgents;
 import com.sitionix.bffssox.usecase.GetAgentRules;
 import com.sitionix.bffssox.usecase.PatchAgentRule;
+import com.sitionix.bffssox.usecase.RejectAgentRule;
 import com.sitionix.bffssox.usecase.PatchAgent;
 import com.sitionix.bffssox.usecase.RestoreAgent;
 import jakarta.validation.Valid;
@@ -95,6 +100,10 @@ public class AgentController implements AgentApi {
     private final PatchAgentRule patchAgentRule;
 
     private final DeleteAgentRule deleteAgentRule;
+
+    private final AcceptAgentRule acceptAgentRule;
+
+    private final RejectAgentRule rejectAgentRule;
 
     @Override
     @PreAuthorize("isAuthenticated()")
@@ -163,8 +172,13 @@ public class AgentController implements AgentApi {
 
     @Override
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentRulesResponseDTO> getAgentRules(final UUID agentId) {
-        final AgentRulesResponse response = this.getAgentRules.execute(agentId);
+    public ResponseEntity<AgentRulesResponseDTO> getAgentRules(final UUID agentId,
+                                                               final AgentRuleStatusDTO status,
+                                                               final AgentRuleAuthorTypeDTO authorType) {
+        final AgentRulesResponse response = this.getAgentRules.execute(
+                agentId,
+                this.agentRuleApiMapper.asGetAgentRulesQuery(status, authorType)
+        );
         return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRulesResponseDto(response));
     }
 
@@ -195,6 +209,26 @@ public class AgentController implements AgentApi {
     public ResponseEntity<DeleteAgentRuleResponseDTO> deleteAgentRule(final UUID agentId, final UUID ruleId) {
         final DeleteAgentRuleResponse response = this.deleteAgentRule.execute(agentId, ruleId);
         return ResponseEntity.ok(this.agentRuleApiMapper.asDeleteAgentRuleResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRuleDTO> acceptAgentRule(final UUID agentId,
+                                                        final UUID ruleId,
+                                                        @Valid final AcceptAgentRuleRequestDTO acceptAgentRuleRequestDTO) {
+        final AgentRule response = this.acceptAgentRule.execute(
+                agentId,
+                ruleId,
+                this.agentRuleApiMapper.asAcceptAgentRuleRequest(acceptAgentRuleRequestDTO)
+        );
+        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRuleDTO> rejectAgentRule(final UUID agentId, final UUID ruleId) {
+        final AgentRule response = this.rejectAgentRule.execute(agentId, ruleId);
+        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
     }
 
     @Override

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/AgentRuleApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/AgentRuleApiMapper.java
@@ -1,14 +1,19 @@
 package com.sitionix.bffssox.mapper;
 
+import com.app_afesox.bffssox.api_first.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import org.mapstruct.Mapper;
 
@@ -23,5 +28,13 @@ public interface AgentRuleApiMapper {
 
     PatchAgentRuleRequest asPatchAgentRuleRequest(PatchAgentRuleRequestDTO src);
 
+    AcceptAgentRuleRequest asAcceptAgentRuleRequest(AcceptAgentRuleRequestDTO src);
+
     DeleteAgentRuleResponseDTO asDeleteAgentRuleResponseDto(DeleteAgentRuleResponse src);
+
+    default GetAgentRulesQuery asGetAgentRulesQuery(final AgentRuleStatusDTO status, final AgentRuleAuthorTypeDTO authorType) {
+        final String statusFilter = status == null ? "ACTIVE" : status.getValue();
+        final String authorTypeFilter = authorType == null ? null : authorType.getValue();
+        return new GetAgentRulesQuery(statusFilter, authorTypeFilter);
+    }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -3,6 +3,7 @@ package com.sitionix.bffssox.controller;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AcceptAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
@@ -18,6 +19,7 @@ import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
@@ -484,5 +486,87 @@ class AgentControllerTest {
         assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
         verify(this.deleteAgentRule).execute(agentId, ruleId);
         verify(this.agentRuleApiMapper).asDeleteAgentRuleResponseDto(response);
+    }
+
+    @Test
+    void givenAgentId_whenRestoreAgent_thenReturnOkResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("ac7e74e9-2fe8-4f03-b6da-e5ec38b69c0f");
+        final Agent response = mock(Agent.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+
+        when(this.restoreAgent.execute(givenAgentId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentDTO> actual = this.agentController.restoreAgent(givenAgentId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.restoreAgent).execute(givenAgentId);
+        verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenAgentId_whenDeleteAgent_thenReturnOkResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("23f2a882-4a92-4d9f-bb6c-aaf3c0295e73");
+        final Agent response = mock(Agent.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+
+        when(this.deleteAgent.execute(givenAgentId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentDTO> actual = this.agentController.deleteAgent(givenAgentId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.deleteAgent).execute(givenAgentId);
+        verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenAcceptAgentRuleRequest_whenAcceptAgentRule_thenReturnOkResponse() {
+        //given
+        final UUID agentId = UUID.fromString("66666666-7777-8888-9999-aaaaaaaaaaaa");
+        final UUID ruleId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        final AcceptAgentRuleRequestDTO requestDTO = mock(AcceptAgentRuleRequestDTO.class);
+        final AcceptAgentRuleRequest request = mock(AcceptAgentRuleRequest.class);
+        final AgentRule response = mock(AgentRule.class);
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+
+        when(this.agentRuleApiMapper.asAcceptAgentRuleRequest(requestDTO)).thenReturn(request);
+        when(this.acceptAgentRule.execute(agentId, ruleId, request)).thenReturn(response);
+        when(this.agentRuleApiMapper.asAgentRuleDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentRuleDTO> actual = this.agentController.acceptAgentRule(agentId, ruleId, requestDTO);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.agentRuleApiMapper).asAcceptAgentRuleRequest(requestDTO);
+        verify(this.acceptAgentRule).execute(agentId, ruleId, request);
+        verify(this.agentRuleApiMapper).asAgentRuleDto(response);
+    }
+
+    @Test
+    void givenAgentAndRuleIds_whenRejectAgentRule_thenReturnOkResponse() {
+        //given
+        final UUID agentId = UUID.fromString("45fb8ef9-020e-4d35-a6d7-e361945f95a2");
+        final UUID ruleId = UUID.fromString("eb36639b-f6d1-47ce-9888-20f605e9cd7f");
+        final AgentRule response = mock(AgentRule.class);
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+
+        when(this.rejectAgentRule.execute(agentId, ruleId)).thenReturn(response);
+        when(this.agentRuleApiMapper.asAgentRuleDto(response)).thenReturn(responseDTO);
+
+        //when
+        final ResponseEntity<AgentRuleDTO> actual = this.agentController.rejectAgentRule(agentId, ruleId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
+        verify(this.rejectAgentRule).execute(agentId, ruleId);
+        verify(this.agentRuleApiMapper).asAgentRuleDto(response);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -3,7 +3,9 @@ package com.sitionix.bffssox.controller;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
@@ -24,6 +26,7 @@ import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
@@ -34,6 +37,7 @@ import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.ActivateAgent;
 import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.ChatAgent;
+import com.sitionix.bffssox.usecase.AcceptAgentRule;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.CreateAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgentRule;
@@ -43,6 +47,7 @@ import com.sitionix.bffssox.usecase.GetAgentConversation;
 import com.sitionix.bffssox.usecase.GetAgentConversations;
 import com.sitionix.bffssox.usecase.GetAgents;
 import com.sitionix.bffssox.usecase.GetAgentRules;
+import com.sitionix.bffssox.usecase.RejectAgentRule;
 import com.sitionix.bffssox.usecase.PatchAgentRule;
 import com.sitionix.bffssox.usecase.PatchAgent;
 import com.sitionix.bffssox.usecase.RestoreAgent;
@@ -128,6 +133,12 @@ class AgentControllerTest {
     @Mock
     private DeleteAgentRule deleteAgentRule;
 
+    @Mock
+    private AcceptAgentRule acceptAgentRule;
+
+    @Mock
+    private RejectAgentRule rejectAgentRule;
+
     @BeforeEach
     void setUp() {
         this.agentController = new AgentController(
@@ -150,7 +161,9 @@ class AgentControllerTest {
                 this.getAgentRules,
                 this.createAgentRule,
                 this.patchAgentRule,
-                this.deleteAgentRule
+                this.deleteAgentRule,
+                this.acceptAgentRule,
+                this.rejectAgentRule
         );
     }
 
@@ -176,7 +189,9 @@ class AgentControllerTest {
                 this.getAgentRules,
                 this.createAgentRule,
                 this.patchAgentRule,
-                this.deleteAgentRule
+                this.deleteAgentRule,
+                this.acceptAgentRule,
+                this.rejectAgentRule
         );
     }
 
@@ -384,18 +399,23 @@ class AgentControllerTest {
     void givenAgentId_whenGetAgentRules_thenReturnOkResponse() {
         //given
         final UUID agentId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        final AgentRuleStatusDTO status = AgentRuleStatusDTO.ACTIVE;
+        final AgentRuleAuthorTypeDTO authorType = AgentRuleAuthorTypeDTO.AI;
+        final GetAgentRulesQuery query = mock(GetAgentRulesQuery.class);
         final AgentRulesResponse response = mock(AgentRulesResponse.class);
         final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
 
-        when(this.getAgentRules.execute(agentId)).thenReturn(response);
+        when(this.agentRuleApiMapper.asGetAgentRulesQuery(status, authorType)).thenReturn(query);
+        when(this.getAgentRules.execute(agentId, query)).thenReturn(response);
         when(this.agentRuleApiMapper.asAgentRulesResponseDto(response)).thenReturn(responseDTO);
 
         //when
-        final ResponseEntity<AgentRulesResponseDTO> actual = this.agentController.getAgentRules(agentId);
+        final ResponseEntity<AgentRulesResponseDTO> actual = this.agentController.getAgentRules(agentId, status, authorType);
 
         //then
         assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.getAgentRules).execute(agentId);
+        verify(this.agentRuleApiMapper).asGetAgentRulesQuery(status, authorType);
+        verify(this.getAgentRules).execute(agentId, query);
         verify(this.agentRuleApiMapper).asAgentRulesResponseDto(response);
     }
 

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentRuleApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentRuleApiMapperTest.java
@@ -1,6 +1,9 @@
 package com.sitionix.bffssox.mapper;
 
+import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO1;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
@@ -48,7 +51,7 @@ class AgentRuleApiMapperTest {
         //given
         final AgentRulesResponse given = new AgentRulesResponse(List.of(this.agentRule()));
         final AgentRulesResponseDTO expected = AgentRulesResponseDTO.builder()
-                .items(List.of(this.agentRuleDto()))
+                .items(List.of(this.agentRuleDto1()))
                 .build();
 
         //when
@@ -62,9 +65,10 @@ class AgentRuleApiMapperTest {
     void givenCreateAgentRuleRequestDto_whenAsCreateAgentRuleRequest_thenReturnDomainRequest() {
         //given
         final CreateAgentRuleRequestDTO given = CreateAgentRuleRequestDTO.builder()
-                .text("Always validate input")
+                .title("Validation")
+                .content("Always validate input")
                 .build();
-        final CreateAgentRuleRequest expected = new CreateAgentRuleRequest("Always validate input");
+        final CreateAgentRuleRequest expected = new CreateAgentRuleRequest("Validation", "Always validate input");
 
         //when
         final CreateAgentRuleRequest actual = this.mapper.asCreateAgentRuleRequest(given);
@@ -77,9 +81,10 @@ class AgentRuleApiMapperTest {
     void givenPatchAgentRuleRequestDto_whenAsPatchAgentRuleRequest_thenReturnDomainRequest() {
         //given
         final PatchAgentRuleRequestDTO given = PatchAgentRuleRequestDTO.builder()
-                .text("Keep structure explicit")
+                .title("Structure")
+                .content("Keep structure explicit")
                 .build();
-        final PatchAgentRuleRequest expected = new PatchAgentRuleRequest("Keep structure explicit");
+        final PatchAgentRuleRequest expected = new PatchAgentRuleRequest("Structure", "Keep structure explicit");
 
         //when
         final PatchAgentRuleRequest actual = this.mapper.asPatchAgentRuleRequest(given);
@@ -106,7 +111,11 @@ class AgentRuleApiMapperTest {
     private AgentRule agentRule() {
         return new AgentRule(
                 UUID.fromString("9a79f65b-ff40-4f39-acfe-a58f089c86f7"),
+                UUID.fromString("2a79f65b-ff40-4f39-acfe-a58f089c86f7"),
+                "Validation",
                 "Always validate input",
+                "ACTIVE",
+                "USER",
                 OffsetDateTime.parse("2026-04-21T10:00:00Z"),
                 OffsetDateTime.parse("2026-04-21T10:00:00Z")
         );
@@ -115,7 +124,24 @@ class AgentRuleApiMapperTest {
     private AgentRuleDTO agentRuleDto() {
         return AgentRuleDTO.builder()
                 .id(UUID.fromString("9a79f65b-ff40-4f39-acfe-a58f089c86f7"))
-                .text("Always validate input")
+                .agentId(UUID.fromString("2a79f65b-ff40-4f39-acfe-a58f089c86f7"))
+                .title("Validation")
+                .content("Always validate input")
+                .status(AgentRuleStatusDTO.ACTIVE)
+                .authorType(AgentRuleAuthorTypeDTO.USER)
+                .createdAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
+                .build();
+    }
+
+    private AgentRuleDTO1 agentRuleDto1() {
+        return AgentRuleDTO1.builder()
+                .id(UUID.fromString("9a79f65b-ff40-4f39-acfe-a58f089c86f7"))
+                .agentId(UUID.fromString("2a79f65b-ff40-4f39-acfe-a58f089c86f7"))
+                .title("Validation")
+                .content("Always validate input")
+                .status(AgentRuleStatusDTO.ACTIVE)
+                .authorType(AgentRuleAuthorTypeDTO.USER)
                 .createdAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
                 .updatedAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
                 .build();

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentRuleApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentRuleApiMapperTest.java
@@ -5,13 +5,16 @@ import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO1;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AcceptAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -103,6 +106,37 @@ class AgentRuleApiMapperTest {
 
         //when
         final DeleteAgentRuleResponseDTO actual = this.mapper.asDeleteAgentRuleResponseDto(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenAcceptAgentRuleRequestDto_whenAsAcceptAgentRuleRequest_thenReturnDomainRequest() {
+        //given
+        final AcceptAgentRuleRequestDTO given = AcceptAgentRuleRequestDTO.builder()
+                .title("Language preference")
+                .content("Always answer in Ukrainian unless requested otherwise.")
+                .build();
+        final AcceptAgentRuleRequest expected = new AcceptAgentRuleRequest(
+                "Language preference",
+                "Always answer in Ukrainian unless requested otherwise."
+        );
+
+        //when
+        final AcceptAgentRuleRequest actual = this.mapper.asAcceptAgentRuleRequest(given);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenNullStatusAndAuthorType_whenAsGetAgentRulesQuery_thenReturnDefaultQuery() {
+        //given
+        final GetAgentRulesQuery expected = new GetAgentRulesQuery("ACTIVE", null);
+
+        //when
+        final GetAgentRulesQuery actual = this.mapper.asGetAgentRulesQuery(null, null);
 
         //then
         assertThat(actual).isEqualTo(expected);

--- a/application/src/main/java/com/sitionix/bffssox/usecase/AcceptAgentRuleImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/AcceptAgentRuleImpl.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
+import com.sitionix.bffssox.domain.AgentRule;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AcceptAgentRuleImpl implements AcceptAgentRule {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public AgentRule execute(final UUID agentId, final UUID ruleId, final AcceptAgentRuleRequest request) {
+        return this.agentClient.acceptAgentRule(agentId, ruleId, request);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentRulesImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentRulesImpl.java
@@ -2,6 +2,7 @@ package com.sitionix.bffssox.usecase;
 
 import com.sitionix.bffssox.client.AgentClient;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,7 +14,7 @@ public class GetAgentRulesImpl implements GetAgentRules {
     private final AgentClient agentClient;
 
     @Override
-    public AgentRulesResponse execute(final UUID agentId) {
-        return this.agentClient.getAgentRules(agentId);
+    public AgentRulesResponse execute(final UUID agentId, final GetAgentRulesQuery query) {
+        return this.agentClient.getAgentRules(agentId, query);
     }
 }

--- a/application/src/main/java/com/sitionix/bffssox/usecase/RejectAgentRuleImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/RejectAgentRuleImpl.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.AgentRule;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RejectAgentRuleImpl implements RejectAgentRule {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public AgentRule execute(final UUID agentId, final UUID ruleId) {
+        return this.agentClient.rejectAgentRule(agentId, ruleId);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/AcceptAgentRuleImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/AcceptAgentRuleImplTest.java
@@ -1,0 +1,56 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
+import com.sitionix.bffssox.domain.AgentRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AcceptAgentRuleImplTest {
+
+    private AcceptAgentRuleImpl acceptAgentRule;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.acceptAgentRule = new AcceptAgentRuleImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenAgentIdAndRuleIdAndRequest_whenExecute_thenDelegateToClient() {
+        //given
+        final UUID agentId = UUID.fromString("4f7cbfcb-1d84-4463-ad97-a8387d4eaaf6");
+        final UUID ruleId = UUID.fromString("89bb4ed2-4c9b-412d-8a68-f4c6f6ec489a");
+        final AcceptAgentRuleRequest request = mock(AcceptAgentRuleRequest.class);
+        final AgentRule expected = mock(AgentRule.class);
+
+        when(this.agentClient.acceptAgentRule(agentId, ruleId, request)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.acceptAgentRule.execute(agentId, ruleId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentClient).acceptAgentRule(agentId, ruleId, request);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/GetAgentRulesImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/GetAgentRulesImplTest.java
@@ -2,6 +2,7 @@ package com.sitionix.bffssox.usecase;
 
 import com.sitionix.bffssox.client.AgentClient;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,15 +40,16 @@ class GetAgentRulesImplTest {
     void givenAgentId_whenExecute_thenDelegateToClient() {
         //given
         final UUID agentId = UUID.fromString("7e31eb53-58bb-4d8d-ac81-f71abecdfb4c");
+        final GetAgentRulesQuery query = new GetAgentRulesQuery("ACTIVE", null);
         final AgentRulesResponse expected = mock(AgentRulesResponse.class);
 
-        when(this.agentClient.getAgentRules(agentId)).thenReturn(expected);
+        when(this.agentClient.getAgentRules(agentId, query)).thenReturn(expected);
 
         //when
-        final AgentRulesResponse actual = this.getAgentRules.execute(agentId);
+        final AgentRulesResponse actual = this.getAgentRules.execute(agentId, query);
 
         //then
         assertThat(actual).isEqualTo(expected);
-        verify(this.agentClient).getAgentRules(agentId);
+        verify(this.agentClient).getAgentRules(agentId, query);
     }
 }

--- a/application/src/test/java/com/sitionix/bffssox/usecase/RejectAgentRuleImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/RejectAgentRuleImplTest.java
@@ -1,0 +1,54 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.AgentRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RejectAgentRuleImplTest {
+
+    private RejectAgentRuleImpl rejectAgentRule;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.rejectAgentRule = new RejectAgentRuleImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenAgentIdAndRuleId_whenExecute_thenDelegateToClient() {
+        //given
+        final UUID agentId = UUID.fromString("4f7cbfcb-1d84-4463-ad97-a8387d4eaaf6");
+        final UUID ruleId = UUID.fromString("89bb4ed2-4c9b-412d-8a68-f4c6f6ec489a");
+        final AgentRule expected = mock(AgentRule.class);
+
+        when(this.agentClient.rejectAgentRule(agentId, ruleId)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.rejectAgentRule.execute(agentId, ruleId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentClient).rejectAgentRule(agentId, ruleId);
+    }
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/request/requestDefaultCreateAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/request/requestDefaultCreateAgentRuleWithHappyPath.json
@@ -1,3 +1,4 @@
 {
-  "text": "Always validate input"
+  "title": "Validation rule",
+  "content": "Always validate input"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/request/requestDefaultPatchAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/request/requestDefaultPatchAgentRuleWithHappyPath.json
@@ -1,3 +1,4 @@
 {
-  "text": "Keep structure explicit"
+  "title": "Structure rule",
+  "content": "Keep structure explicit"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultCreateAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultCreateAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Always validate input",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Validation rule",
+  "content": "Always validate input",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:00:00Z"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultGetAgentRulesWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultGetAgentRulesWithHappyPath.json
@@ -2,7 +2,11 @@
   "items": [
     {
       "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-      "text": "Always validate input",
+      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "title": "Validation rule",
+      "content": "Always validate input",
+      "status": "ACTIVE",
+      "authorType": "USER",
       "createdAt": "2026-04-21T10:00:00Z",
       "updatedAt": "2026-04-21T10:00:00Z"
     }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultPatchAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultPatchAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Keep structure explicit",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Structure rule",
+  "content": "Keep structure explicit",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:05:00Z"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/response/responseDefaultCreateAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/response/responseDefaultCreateAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Always validate input",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Validation rule",
+  "content": "Always validate input",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:00:00Z"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/response/responseDefaultGetAgentRulesWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/response/responseDefaultGetAgentRulesWithHappyPath.json
@@ -2,7 +2,11 @@
   "items": [
     {
       "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-      "text": "Always validate input",
+      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "title": "Validation rule",
+      "content": "Always validate input",
+      "status": "ACTIVE",
+      "authorType": "USER",
       "createdAt": "2026-04-21T10:00:00Z",
       "updatedAt": "2026-04-21T10:00:00Z"
     }

--- a/boot/src/test/resources/forge-it/mockmvc/response/responseDefaultPatchAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/mockmvc/response/responseDefaultPatchAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Keep structure explicit",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Structure rule",
+  "content": "Keep structure explicit",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:05:00Z"
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/request/requestDefaultMappingCreateAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/request/requestDefaultMappingCreateAgentRuleWithHappyPath.json
@@ -1,3 +1,4 @@
 {
-  "text": "Always validate input"
+  "title": "Validation rule",
+  "content": "Always validate input"
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/request/requestDefaultMappingPatchAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/request/requestDefaultMappingPatchAgentRuleWithHappyPath.json
@@ -1,3 +1,4 @@
 {
-  "text": "Keep structure explicit"
+  "title": "Structure rule",
+  "content": "Keep structure explicit"
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingCreateAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingCreateAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Always validate input",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Validation rule",
+  "content": "Always validate input",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:00:00Z"
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentRulesWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentRulesWithHappyPath.json
@@ -2,7 +2,11 @@
   "items": [
     {
       "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-      "text": "Always validate input",
+      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "title": "Validation rule",
+      "content": "Always validate input",
+      "status": "ACTIVE",
+      "authorType": "USER",
       "createdAt": "2026-04-21T10:00:00Z",
       "updatedAt": "2026-04-21T10:00:00Z"
     }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingPatchAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingPatchAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Keep structure explicit",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Structure rule",
+  "content": "Keep structure explicit",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:05:00Z"
 }

--- a/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingCreateAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingCreateAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Always validate input",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Validation rule",
+  "content": "Always validate input",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:00:00Z"
 }

--- a/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentRulesWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentRulesWithHappyPath.json
@@ -2,7 +2,11 @@
   "items": [
     {
       "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-      "text": "Always validate input",
+      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "title": "Validation rule",
+      "content": "Always validate input",
+      "status": "ACTIVE",
+      "authorType": "USER",
       "createdAt": "2026-04-21T10:00:00Z",
       "updatedAt": "2026-04-21T10:00:00Z"
     }

--- a/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingPatchAgentRuleWithHappyPath.json
+++ b/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingPatchAgentRuleWithHappyPath.json
@@ -1,6 +1,10 @@
 {
   "id": "9a79f65b-ff40-4f39-acfe-a58f089c86f7",
-  "text": "Keep structure explicit",
+  "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+  "title": "Structure rule",
+  "content": "Keep structure explicit",
+  "status": "ACTIVE",
+  "authorType": "USER",
   "createdAt": "2026-04-21T10:00:00Z",
   "updatedAt": "2026-04-21T10:05:00Z"
 }

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.11</atmssox.api.version>
+        <atmssox.api.version>0.0.12</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-119-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-sitionix-119-unstable</artifactId>
+            <artifactId>app-afesox-atmssox-client-stable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -3,8 +3,11 @@ package com.sitionix.bffssox.client;
 import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
+import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
 import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
@@ -17,6 +20,7 @@ import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
@@ -25,6 +29,7 @@ import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
@@ -126,9 +131,13 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     }
 
     @Override
-    public AgentRulesResponse getAgentRules(final UUID agentId) {
+    public AgentRulesResponse getAgentRules(final UUID agentId, final GetAgentRulesQuery query) {
+        final AgentRuleStatusDTO status = query == null || query.status() == null ? null : AgentRuleStatusDTO.fromValue(query.status());
+        final AgentRuleAuthorTypeDTO authorType = query == null || query.authorType() == null
+                ? null
+                : AgentRuleAuthorTypeDTO.fromValue(query.authorType());
         final AgentRulesResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentRules(agentId)
+                () -> this.agentApi.getAgentRules(agentId, status, authorType)
         );
         return this.agentRuleClientMapper.asAgentRulesResponse(responseDTO);
     }
@@ -147,6 +156,23 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
         final PatchAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asPatchAgentRuleRequestDto(request);
         final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
                 () -> this.agentApi.patchAgentRule(agentId, ruleId, requestDTO)
+        );
+        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+    }
+
+    @Override
+    public AgentRule acceptAgentRule(final UUID agentId, final UUID ruleId, final AcceptAgentRuleRequest request) {
+        final AcceptAgentRuleRequestDTO requestDTO = request == null ? null : this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request);
+        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentApi.acceptAgentRule(agentId, ruleId, requestDTO)
+        );
+        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+    }
+
+    @Override
+    public AgentRule rejectAgentRule(final UUID agentId, final UUID ruleId) {
+        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentApi.rejectAgentRule(agentId, ruleId)
         );
         return this.agentRuleClientMapper.asAgentRule(responseDTO);
     }

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/AgentRuleClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/AgentRuleClientMapper.java
@@ -1,10 +1,12 @@
 package com.sitionix.bffssox.mapper;
 
+import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
 import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.atmssox.client.dto.DeleteAgentRuleResponseDTO;
 import com.app_afesox.atmssox.client.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
@@ -22,6 +24,8 @@ public interface AgentRuleClientMapper {
     CreateAgentRuleRequestDTO asCreateAgentRuleRequestDto(CreateAgentRuleRequest src);
 
     PatchAgentRuleRequestDTO asPatchAgentRuleRequestDto(PatchAgentRuleRequest src);
+
+    AcceptAgentRuleRequestDTO asAcceptAgentRuleRequestDto(AcceptAgentRuleRequest src);
 
     DeleteAgentRuleResponse asDeleteAgentRuleResponse(DeleteAgentRuleResponseDTO src);
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -4,6 +4,7 @@ import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
+import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
@@ -19,6 +20,7 @@ import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
@@ -403,6 +405,30 @@ class AgentClientImplTest {
     }
 
     @Test
+    void givenAgentIdAndNullQuery_whenGetAgentRules_thenReturnAgentRulesResponse() {
+        //given
+        final UUID givenAgentId = UUID.fromString("52418b95-6688-4c7e-a7ef-08eeceddd153");
+        final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
+        final AgentRulesResponse expected = mock(AgentRulesResponse.class);
+
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentRulesResponseDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.getAgentRules(givenAgentId, null, null)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRulesResponse actual = this.agentClient.getAgentRules(givenAgentId, null);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).getAgentRules(givenAgentId, null, null);
+        verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
+    }
+
+    @Test
     void givenAgentIdAndRuleRequest_whenCreateAgentRule_thenReturnAgentRule() {
         //given
         final UUID givenAgentId = UUID.fromString("fc22a352-fcc8-4765-a9f8-959518f0689f");
@@ -456,6 +482,85 @@ class AgentClientImplTest {
         verify(this.agentRuleClientMapper).asPatchAgentRuleRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentApi).patchAgentRule(givenAgentId, givenRuleId, requestDTO);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenAgentAndRuleIdsAndNullAcceptRequest_whenAcceptAgentRule_thenReturnAgentRule() {
+        //given
+        final UUID givenAgentId = UUID.fromString("92456ccf-6595-4f4a-88f7-5f9ed79046fe");
+        final UUID givenRuleId = UUID.fromString("e2b9d7cb-f69a-405d-b44f-e95dbd7e08ee");
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.acceptAgentRule(givenAgentId, givenRuleId, null)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentClient.acceptAgentRule(givenAgentId, givenRuleId, null);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).acceptAgentRule(givenAgentId, givenRuleId, null);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenAgentAndRuleIdsAndAcceptRequest_whenAcceptAgentRule_thenReturnAgentRule() {
+        //given
+        final UUID givenAgentId = UUID.fromString("f46cd205-0809-4fd3-832f-3358f71339df");
+        final UUID givenRuleId = UUID.fromString("c22311b0-5b92-4d98-b04e-eb2fbe34f8ca");
+        final AcceptAgentRuleRequest request = mock(AcceptAgentRuleRequest.class);
+        final AcceptAgentRuleRequestDTO requestDTO = mock(AcceptAgentRuleRequestDTO.class);
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+
+        when(this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.acceptAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentClient.acceptAgentRule(givenAgentId, givenRuleId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentRuleClientMapper).asAcceptAgentRuleRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).acceptAgentRule(givenAgentId, givenRuleId, requestDTO);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenAgentAndRuleIds_whenRejectAgentRule_thenReturnAgentRule() {
+        //given
+        final UUID givenAgentId = UUID.fromString("465cd2f0-2dd5-4847-bd99-f6bfd8c7f331");
+        final UUID givenRuleId = UUID.fromString("60af08a3-0a29-4f27-8a74-f0f29695f90c");
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
+            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
+            return supplier.get();
+        });
+        when(this.agentApi.rejectAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentClient.rejectAgentRule(givenAgentId, givenRuleId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).rejectAgentRule(givenAgentId, givenRuleId);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
     }
 

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -4,7 +4,9 @@ import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
 import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
@@ -25,6 +27,7 @@ import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
@@ -378,6 +381,7 @@ class AgentClientImplTest {
     void givenAgentId_whenGetAgentRules_thenReturnAgentRulesResponse() {
         //given
         final UUID givenAgentId = UUID.fromString("d9ac51e6-9711-40b8-b5bc-fbafdb9f8c08");
+        final GetAgentRulesQuery query = new GetAgentRulesQuery("ACTIVE", "AI");
         final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
         final AgentRulesResponse expected = mock(AgentRulesResponse.class);
 
@@ -385,16 +389,16 @@ class AgentClientImplTest {
             final Supplier<AgentRulesResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentRules(givenAgentId)).thenReturn(responseDTO);
+        when(this.agentApi.getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
 
         //when
-        final AgentRulesResponse actual = this.agentClient.getAgentRules(givenAgentId);
+        final AgentRulesResponse actual = this.agentClient.getAgentRules(givenAgentId, query);
 
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentRules(givenAgentId);
+        verify(this.agentApi).getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI);
         verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
     }
 

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/AgentRuleClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/AgentRuleClientMapperTest.java
@@ -1,6 +1,9 @@
 package com.sitionix.bffssox.mapper;
 
+import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleDTO1;
+import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
 import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.atmssox.client.dto.DeleteAgentRuleResponseDTO;
@@ -47,7 +50,7 @@ class AgentRuleClientMapperTest {
     void givenAgentRulesResponseDto_whenAsAgentRulesResponse_thenReturnDomainResponse() {
         //given
         final AgentRulesResponseDTO given = AgentRulesResponseDTO.builder()
-                .items(List.of(this.agentRuleDto()))
+                .items(List.of(this.agentRuleDto1()))
                 .build();
         final AgentRulesResponse expected = new AgentRulesResponse(List.of(this.agentRule()));
 
@@ -61,9 +64,10 @@ class AgentRuleClientMapperTest {
     @Test
     void givenCreateAgentRuleRequest_whenAsCreateAgentRuleRequestDto_thenReturnClientRequest() {
         //given
-        final CreateAgentRuleRequest given = new CreateAgentRuleRequest("Always validate input");
+        final CreateAgentRuleRequest given = new CreateAgentRuleRequest("Validation", "Always validate input");
         final CreateAgentRuleRequestDTO expected = CreateAgentRuleRequestDTO.builder()
-                .text("Always validate input")
+                .title("Validation")
+                .content("Always validate input")
                 .build();
 
         //when
@@ -76,9 +80,10 @@ class AgentRuleClientMapperTest {
     @Test
     void givenPatchAgentRuleRequest_whenAsPatchAgentRuleRequestDto_thenReturnClientRequest() {
         //given
-        final PatchAgentRuleRequest given = new PatchAgentRuleRequest("Keep output deterministic");
+        final PatchAgentRuleRequest given = new PatchAgentRuleRequest("Determinism", "Keep output deterministic");
         final PatchAgentRuleRequestDTO expected = PatchAgentRuleRequestDTO.builder()
-                .text("Keep output deterministic")
+                .title("Determinism")
+                .content("Keep output deterministic")
                 .build();
 
         //when
@@ -106,7 +111,24 @@ class AgentRuleClientMapperTest {
     private AgentRuleDTO agentRuleDto() {
         return AgentRuleDTO.builder()
                 .id(UUID.fromString("7f4ef04a-5365-43cc-8d10-98ef51f35b8d"))
-                .text("Always validate input")
+                .agentId(UUID.fromString("6f4ef04a-5365-43cc-8d10-98ef51f35b8d"))
+                .title("Validation")
+                .content("Always validate input")
+                .status(AgentRuleStatusDTO.ACTIVE)
+                .authorType(AgentRuleAuthorTypeDTO.USER)
+                .createdAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
+                .build();
+    }
+
+    private AgentRuleDTO1 agentRuleDto1() {
+        return AgentRuleDTO1.builder()
+                .id(UUID.fromString("7f4ef04a-5365-43cc-8d10-98ef51f35b8d"))
+                .agentId(UUID.fromString("6f4ef04a-5365-43cc-8d10-98ef51f35b8d"))
+                .title("Validation")
+                .content("Always validate input")
+                .status(AgentRuleStatusDTO.ACTIVE)
+                .authorType(AgentRuleAuthorTypeDTO.USER)
                 .createdAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
                 .updatedAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
                 .build();
@@ -115,7 +137,11 @@ class AgentRuleClientMapperTest {
     private AgentRule agentRule() {
         return new AgentRule(
                 UUID.fromString("7f4ef04a-5365-43cc-8d10-98ef51f35b8d"),
+                UUID.fromString("6f4ef04a-5365-43cc-8d10-98ef51f35b8d"),
+                "Validation",
                 "Always validate input",
+                "ACTIVE",
+                "USER",
                 OffsetDateTime.parse("2026-04-21T10:00:00Z"),
                 OffsetDateTime.parse("2026-04-21T10:00:00Z")
         );

--- a/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
+++ b/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
@@ -5,12 +5,14 @@ import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import java.util.UUID;
@@ -91,11 +93,15 @@ public interface AgentClient {
      */
     Agent deleteAgent(UUID agentId);
 
-    AgentRulesResponse getAgentRules(UUID agentId);
+    AgentRulesResponse getAgentRules(UUID agentId, GetAgentRulesQuery query);
 
     AgentRule createAgentRule(UUID agentId, CreateAgentRuleRequest request);
 
     AgentRule patchAgentRule(UUID agentId, UUID ruleId, PatchAgentRuleRequest request);
+
+    AgentRule acceptAgentRule(UUID agentId, UUID ruleId, AcceptAgentRuleRequest request);
+
+    AgentRule rejectAgentRule(UUID agentId, UUID ruleId);
 
     DeleteAgentRuleResponse deleteAgentRule(UUID agentId, UUID ruleId);
 

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AcceptAgentRuleRequest.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AcceptAgentRuleRequest.java
@@ -1,6 +1,6 @@
 package com.sitionix.bffssox.domain;
 
-public record PatchAgentRuleRequest(
+public record AcceptAgentRuleRequest(
         String title,
         String content
 ) {

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentRule.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentRule.java
@@ -5,7 +5,11 @@ import java.util.UUID;
 
 public record AgentRule(
         UUID id,
-        String text,
+        UUID agentId,
+        String title,
+        String content,
+        String status,
+        String authorType,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt
 ) {

--- a/domain/src/main/java/com/sitionix/bffssox/domain/CreateAgentRuleRequest.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/CreateAgentRuleRequest.java
@@ -1,6 +1,7 @@
 package com.sitionix.bffssox.domain;
 
 public record CreateAgentRuleRequest(
-        String text
+        String title,
+        String content
 ) {
 }

--- a/domain/src/main/java/com/sitionix/bffssox/domain/GetAgentRulesQuery.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/GetAgentRulesQuery.java
@@ -1,0 +1,7 @@
+package com.sitionix.bffssox.domain;
+
+public record GetAgentRulesQuery(
+        String status,
+        String authorType
+) {
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/AcceptAgentRule.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/AcceptAgentRule.java
@@ -1,0 +1,21 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
+import com.sitionix.bffssox.domain.AgentRule;
+import java.util.UUID;
+
+/**
+ * Use case for accepting one automation rule through BFF.
+ */
+public interface AcceptAgentRule {
+
+    /**
+     * Accepts one rule for one agent.
+     *
+     * @param agentId agent identifier.
+     * @param ruleId rule identifier.
+     * @param request optional title/content update payload.
+     * @return updated rule.
+     */
+    AgentRule execute(UUID agentId, UUID ruleId, AcceptAgentRuleRequest request);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentRules.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentRules.java
@@ -1,9 +1,10 @@
 package com.sitionix.bffssox.usecase;
 
 import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import java.util.UUID;
 
 public interface GetAgentRules {
 
-    AgentRulesResponse execute(UUID agentId);
+    AgentRulesResponse execute(UUID agentId, GetAgentRulesQuery query);
 }

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/RejectAgentRule.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/RejectAgentRule.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.AgentRule;
+import java.util.UUID;
+
+/**
+ * Use case for rejecting one suggested automation rule through BFF.
+ */
+public interface RejectAgentRule {
+
+    /**
+     * Rejects one rule for one agent.
+     *
+     * @param agentId agent identifier.
+     * @param ruleId rule identifier.
+     * @return updated rule.
+     */
+    AgentRule execute(UUID agentId, UUID ruleId);
+}


### PR DESCRIPTION
Extends BFF agent rule facade with status/author filters and accept/reject passthrough endpoints.