### PR TITLE
[SITIONIX-126] - implement async agent chat execution lifecycle facade

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.28</bffssox.api.version>
+        <bffssox.api.version>0.0.31</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-126-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
@@ -5,15 +5,19 @@ import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
@@ -21,9 +25,11 @@ import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.AgentRuleApiMapper;
 import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
@@ -37,6 +43,7 @@ import com.sitionix.bffssox.usecase.CreateAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgent;
 import com.sitionix.bffssox.usecase.GetAgent;
+import com.sitionix.bffssox.usecase.GetAgentChatExecution;
 import com.sitionix.bffssox.usecase.GetAgentConversation;
 import com.sitionix.bffssox.usecase.GetAgentConversations;
 import com.sitionix.bffssox.usecase.GetAgents;
@@ -44,6 +51,7 @@ import com.sitionix.bffssox.usecase.GetAgentRules;
 import com.sitionix.bffssox.usecase.PatchAgentRule;
 import com.sitionix.bffssox.usecase.PatchAgent;
 import com.sitionix.bffssox.usecase.RestoreAgent;
+import com.sitionix.bffssox.usecase.SubmitAgentChatExecution;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -57,43 +65,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class AgentController implements AgentApi {
 
     private final CreateAgentApiMapper createAgentApiMapper;
-
     private final AgentApiMapper agentApiMapper;
-
     private final AgentRuleApiMapper agentRuleApiMapper;
-
     private final CreateAgent createAgent;
-
     private final PatchAgentApiMapper patchAgentApiMapper;
-
     private final PatchAgent patchAgent;
-
     private final ChatAgentApiMapper chatAgentApiMapper;
-
     private final ChatAgent chatAgent;
-
+    private final SubmitAgentChatExecution submitAgentChatExecution;
+    private final GetAgentChatExecution getAgentChatExecution;
     private final GetAgents getAgents;
-
     private final GetAgent getAgent;
-
     private final GetAgentConversations getAgentConversations;
-
     private final GetAgentConversation getAgentConversation;
-
     private final ActivateAgent activateAgent;
-
     private final ArchiveAgent archiveAgent;
-
     private final RestoreAgent restoreAgent;
-
     private final DeleteAgent deleteAgent;
-
     private final GetAgentRules getAgentRules;
-
     private final CreateAgentRule createAgentRule;
-
     private final PatchAgentRule patchAgentRule;
-
     private final DeleteAgentRule deleteAgentRule;
 
     @Override
@@ -101,8 +92,7 @@ public class AgentController implements AgentApi {
     public ResponseEntity<AgentDTO> createAgent(@Valid final CreateAgentRequestDTO createAgentRequestDTO) {
         final CreateAgentRequest request = this.createAgentApiMapper.asCreateAgentRequest(createAgentRequestDTO);
         final Agent response = this.createAgent.execute(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(this.agentApiMapper.asAgentDto(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(this.agentApiMapper.asAgentDto(response));
     }
 
     @Override
@@ -163,7 +153,9 @@ public class AgentController implements AgentApi {
 
     @Override
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentRulesResponseDTO> getAgentRules(final UUID agentId) {
+    public ResponseEntity<AgentRulesResponseDTO> getAgentRules(final UUID agentId,
+                                                               final AgentRuleStatusDTO status,
+                                                               final AgentRuleAuthorTypeDTO authorType) {
         final AgentRulesResponse response = this.getAgentRules.execute(agentId);
         return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRulesResponseDto(response));
     }
@@ -173,8 +165,7 @@ public class AgentController implements AgentApi {
     public ResponseEntity<AgentRuleDTO> createAgentRule(final UUID agentId, @Valid final CreateAgentRuleRequestDTO createAgentRuleRequestDTO) {
         final CreateAgentRuleRequest request = this.agentRuleApiMapper.asCreateAgentRuleRequest(createAgentRuleRequestDTO);
         final AgentRule response = this.createAgentRule.execute(agentId, request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(this.agentRuleApiMapper.asAgentRuleDto(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(this.agentRuleApiMapper.asAgentRuleDto(response));
     }
 
     @Override
@@ -182,11 +173,7 @@ public class AgentController implements AgentApi {
     public ResponseEntity<AgentRuleDTO> patchAgentRule(final UUID agentId,
                                                        final UUID ruleId,
                                                        @Valid final PatchAgentRuleRequestDTO patchAgentRuleRequestDTO) {
-        final AgentRule response = this.patchAgentRule.execute(
-                agentId,
-                ruleId,
-                this.agentRuleApiMapper.asPatchAgentRuleRequest(patchAgentRuleRequestDTO)
-        );
+        final AgentRule response = this.patchAgentRule.execute(agentId, ruleId, this.agentRuleApiMapper.asPatchAgentRuleRequest(patchAgentRuleRequestDTO));
         return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
     }
 
@@ -199,9 +186,32 @@ public class AgentController implements AgentApi {
 
     @Override
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ChatAgentResponseDTO> chatAgent(final UUID agentId, @Valid final ChatAgentRequestDTO chatAgentRequestDTO) {
-        final ChatAgentResponse response = this.chatAgent.execute(agentId, this.chatAgentApiMapper.asChatAgentRequest(chatAgentRequestDTO));
-        return ResponseEntity.ok(this.chatAgentApiMapper.asChatAgentResponseDto(response));
+    public ResponseEntity<SubmitChatExecutionResponseDTO> submitAgentChatExecution(final UUID agentId,
+                                                                                    @Valid final ChatAgentRequestDTO chatAgentRequestDTO,
+                                                                                    final String idempotencyKey) {
+        final SubmitChatExecutionResponse response = this.submitAgentChatExecution.execute(
+                agentId,
+                this.chatAgentApiMapper.asChatAgentRequest(chatAgentRequestDTO),
+                idempotencyKey
+        );
+        return ResponseEntity.accepted().body(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<SubmitChatExecutionResponseDTO> submitAgentChatExecutionByExecutionsPath(final UUID agentId,
+                                                                                                    @Valid final ChatAgentRequestDTO chatAgentRequestDTO,
+                                                                                                    final String idempotencyKey) {
+        return this.submitAgentChatExecution(agentId, chatAgentRequestDTO, idempotencyKey);
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ChatExecutionDTO> getAgentChatExecution(final UUID agentId,
+                                                                  final UUID executionId,
+                                                                  final UUID conversationId) {
+        final ChatExecution response = this.getAgentChatExecution.execute(agentId, executionId, conversationId);
+        return ResponseEntity.ok(this.chatAgentApiMapper.asChatExecutionDto(response));
     }
 
     @Override

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/AgentRuleApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/AgentRuleApiMapper.java
@@ -11,16 +11,20 @@ import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface AgentRuleApiMapper {
 
+    @Mapping(target = "content", source = "text")
     AgentRuleDTO asAgentRuleDto(AgentRule src);
 
     AgentRulesResponseDTO asAgentRulesResponseDto(AgentRulesResponse src);
 
+    @Mapping(target = "text", source = "content")
     CreateAgentRuleRequest asCreateAgentRuleRequest(CreateAgentRuleRequestDTO src);
 
+    @Mapping(target = "text", source = "content")
     PatchAgentRuleRequest asPatchAgentRuleRequest(PatchAgentRuleRequestDTO src);
 
     DeleteAgentRuleResponseDTO asDeleteAgentRuleResponseDto(DeleteAgentRuleResponse src);

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -5,13 +5,20 @@ import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationMessageDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionFailureDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.ExecutionStatusDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.AgentConversation;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.ChatExecutionFailure;
 import com.sitionix.bffssox.domain.ChatAgentMessage;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.util.List;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mapper;
@@ -22,6 +29,12 @@ public interface ChatAgentApiMapper {
     ChatAgentRequest asChatAgentRequest(ChatAgentRequestDTO src);
 
     ChatAgentResponseDTO asChatAgentResponseDto(ChatAgentResponse src);
+
+    SubmitChatExecutionResponseDTO asSubmitChatExecutionResponseDto(SubmitChatExecutionResponse src);
+
+    ChatExecutionDTO asChatExecutionDto(ChatExecution src);
+
+    ChatExecutionFailureDTO asChatExecutionFailureDto(ChatExecutionFailure src);
 
     AgentConversationDTO asAgentConversationDto(AgentConversation src);
 
@@ -47,5 +60,13 @@ public interface ChatAgentApiMapper {
 
     default AgentConversationMessageDTO.AuthorTypeEnum mapAuthorType(final String value) {
         return value == null ? null : AgentConversationMessageDTO.AuthorTypeEnum.fromValue(value);
+    }
+
+    default ExecutionStatusDTO mapExecutionStatus(final String value) {
+        return value == null ? null : ExecutionStatusDTO.fromValue(value);
+    }
+
+    default ChatExecutionFailureDTO.FailureClassEnum mapFailureClass(final String value) {
+        return value == null ? null : ChatExecutionFailureDTO.FailureClassEnum.fromValue(value);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -1,31 +1,15 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
-import com.sitionix.bffssox.domain.AgentConversationDetails;
-import com.sitionix.bffssox.domain.AgentConversationsResponse;
-import com.sitionix.bffssox.domain.AgentRule;
-import com.sitionix.bffssox.domain.AgentRulesResponse;
-import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
-import com.sitionix.bffssox.domain.ChatAgentResponse;
-import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
+import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
-import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
-import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
-import com.sitionix.bffssox.domain.PatchAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.AgentRuleApiMapper;
 import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
@@ -36,16 +20,18 @@ import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.ChatAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
 import com.sitionix.bffssox.usecase.CreateAgentRule;
-import com.sitionix.bffssox.usecase.DeleteAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgent;
+import com.sitionix.bffssox.usecase.DeleteAgentRule;
 import com.sitionix.bffssox.usecase.GetAgent;
+import com.sitionix.bffssox.usecase.GetAgentChatExecution;
 import com.sitionix.bffssox.usecase.GetAgentConversation;
 import com.sitionix.bffssox.usecase.GetAgentConversations;
-import com.sitionix.bffssox.usecase.GetAgents;
 import com.sitionix.bffssox.usecase.GetAgentRules;
-import com.sitionix.bffssox.usecase.PatchAgentRule;
+import com.sitionix.bffssox.usecase.GetAgents;
 import com.sitionix.bffssox.usecase.PatchAgent;
+import com.sitionix.bffssox.usecase.PatchAgentRule;
 import com.sitionix.bffssox.usecase.RestoreAgent;
+import com.sitionix.bffssox.usecase.SubmitAgentChatExecution;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +43,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -68,65 +53,28 @@ class AgentControllerTest {
 
     private AgentController agentController;
 
-    @Mock
-    private CreateAgentApiMapper createAgentApiMapper;
-
-    @Mock
-    private AgentApiMapper agentApiMapper;
-
-    @Mock
-    private AgentRuleApiMapper agentRuleApiMapper;
-
-    @Mock
-    private CreateAgent createAgent;
-
-    @Mock
-    private PatchAgentApiMapper patchAgentApiMapper;
-
-    @Mock
-    private PatchAgent patchAgent;
-
-    @Mock
-    private ChatAgentApiMapper chatAgentApiMapper;
-
-    @Mock
-    private ChatAgent chatAgent;
-
-    @Mock
-    private GetAgents getAgents;
-
-    @Mock
-    private GetAgent getAgent;
-
-    @Mock
-    private GetAgentConversations getAgentConversations;
-
-    @Mock
-    private GetAgentConversation getAgentConversation;
-
-    @Mock
-    private ActivateAgent activateAgent;
-
-    @Mock
-    private ArchiveAgent archiveAgent;
-
-    @Mock
-    private RestoreAgent restoreAgent;
-
-    @Mock
-    private DeleteAgent deleteAgent;
-
-    @Mock
-    private GetAgentRules getAgentRules;
-
-    @Mock
-    private CreateAgentRule createAgentRule;
-
-    @Mock
-    private PatchAgentRule patchAgentRule;
-
-    @Mock
-    private DeleteAgentRule deleteAgentRule;
+    @Mock private CreateAgentApiMapper createAgentApiMapper;
+    @Mock private AgentApiMapper agentApiMapper;
+    @Mock private AgentRuleApiMapper agentRuleApiMapper;
+    @Mock private CreateAgent createAgent;
+    @Mock private PatchAgentApiMapper patchAgentApiMapper;
+    @Mock private PatchAgent patchAgent;
+    @Mock private ChatAgentApiMapper chatAgentApiMapper;
+    @Mock private ChatAgent chatAgent;
+    @Mock private SubmitAgentChatExecution submitAgentChatExecution;
+    @Mock private GetAgentChatExecution getAgentChatExecution;
+    @Mock private GetAgents getAgents;
+    @Mock private GetAgent getAgent;
+    @Mock private GetAgentConversations getAgentConversations;
+    @Mock private GetAgentConversation getAgentConversation;
+    @Mock private ActivateAgent activateAgent;
+    @Mock private ArchiveAgent archiveAgent;
+    @Mock private RestoreAgent restoreAgent;
+    @Mock private DeleteAgent deleteAgent;
+    @Mock private GetAgentRules getAgentRules;
+    @Mock private CreateAgentRule createAgentRule;
+    @Mock private PatchAgentRule patchAgentRule;
+    @Mock private DeleteAgentRule deleteAgentRule;
 
     @BeforeEach
     void setUp() {
@@ -139,6 +87,8 @@ class AgentControllerTest {
                 this.patchAgent,
                 this.chatAgentApiMapper,
                 this.chatAgent,
+                this.submitAgentChatExecution,
+                this.getAgentChatExecution,
                 this.getAgents,
                 this.getAgent,
                 this.getAgentConversations,
@@ -165,6 +115,8 @@ class AgentControllerTest {
                 this.patchAgent,
                 this.chatAgentApiMapper,
                 this.chatAgent,
+                this.submitAgentChatExecution,
+                this.getAgentChatExecution,
                 this.getAgents,
                 this.getAgent,
                 this.getAgentConversations,
@@ -183,286 +135,68 @@ class AgentControllerTest {
     @Test
     void givenCreateAgentRequestDto_whenCreateAgent_thenReturnCreatedResponse() {
         //given
-        final CreateAgentRequestDTO requestDTO = mock(CreateAgentRequestDTO.class);
+        final CreateAgentRequestDTO requestDto = mock(CreateAgentRequestDTO.class);
         final CreateAgentRequest request = mock(CreateAgentRequest.class);
         final Agent response = mock(Agent.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final AgentDTO responseDto = mock(AgentDTO.class);
 
-        when(this.createAgentApiMapper.asCreateAgentRequest(requestDTO)).thenReturn(request);
+        when(this.createAgentApiMapper.asCreateAgentRequest(requestDto)).thenReturn(request);
         when(this.createAgent.execute(request)).thenReturn(response);
-        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDto);
 
         //when
-        final ResponseEntity<AgentDTO> actual = this.agentController.createAgent(requestDTO);
+        final ResponseEntity<AgentDTO> actual = this.agentController.createAgent(requestDto);
 
         //then
-        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(responseDTO));
-        verify(this.createAgentApiMapper).asCreateAgentRequest(requestDTO);
+        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(responseDto));
+        verify(this.createAgentApiMapper).asCreateAgentRequest(requestDto);
         verify(this.createAgent).execute(request);
         verify(this.agentApiMapper).asAgentDto(response);
     }
 
     @Test
-    void givenGetAgentsRequest_whenGetAgents_thenReturnOkResponse() {
+    void givenSubmitExecutionRequest_whenSubmitAgentChatExecution_thenReturnAcceptedEnvelope() {
         //given
-        final AgentsResponse response = mock(AgentsResponse.class);
-        final AgentsResponseDTO responseDTO = mock(AgentsResponseDTO.class);
-
-        when(this.getAgents.execute()).thenReturn(response);
-        when(this.agentApiMapper.asAgentsResponseDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentsResponseDTO> actual = this.agentController.getAgents();
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.getAgents).execute();
-        verify(this.agentApiMapper).asAgentsResponseDto(response);
-    }
-
-    @Test
-    void givenAgentId_whenGetAgent_thenReturnOkResponse() {
-        //given
-        final UUID agentId = UUID.fromString("ebac37f0-90a2-4f6b-ab99-73f6ac5cf675");
-        final Agent response = mock(Agent.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-
-        when(this.getAgent.execute(agentId)).thenReturn(response);
-        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentDTO> actual = this.agentController.getAgent(agentId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.getAgent).execute(agentId);
-        verify(this.agentApiMapper).asAgentDto(response);
-    }
-
-    @Test
-    void givenAgentId_whenGetAgentConversations_thenReturnOkResponse() {
-        //given
-        final UUID agentId = UUID.fromString("dbac37f0-90a2-4f6b-ab99-73f6ac5cf675");
-        final AgentConversationsResponse response = mock(AgentConversationsResponse.class);
-        final AgentConversationsResponseDTO responseDTO = mock(AgentConversationsResponseDTO.class);
-
-        when(this.getAgentConversations.execute(agentId)).thenReturn(response);
-        when(this.chatAgentApiMapper.asAgentConversationsResponseDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentConversationsResponseDTO> actual = this.agentController.getAgentConversations(agentId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.getAgentConversations).execute(agentId);
-        verify(this.chatAgentApiMapper).asAgentConversationsResponseDto(response);
-    }
-
-    @Test
-    void givenConversationId_whenGetAgentConversation_thenReturnOkResponse() {
-        //given
-        final UUID conversationId = UUID.fromString("fbbc37f0-90a2-4f6b-ab99-73f6ac5cf675");
-        final AgentConversationDetails response = mock(AgentConversationDetails.class);
-        final AgentConversationDetailsDTO responseDTO = mock(AgentConversationDetailsDTO.class);
-
-        when(this.getAgentConversation.execute(conversationId)).thenReturn(response);
-        when(this.chatAgentApiMapper.asAgentConversationDetailsDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentConversationDetailsDTO> actual =
-                this.agentController.getAgentConversation(conversationId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.getAgentConversation).execute(conversationId);
-        verify(this.chatAgentApiMapper).asAgentConversationDetailsDto(response);
-    }
-
-    @Test
-    void givenPatchAgentRequestDto_whenPatchAgent_thenReturnOkResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("ebac37f0-90a2-4f6b-ab99-73f6ac5cf675");
-        final PatchAgentRequestDTO givenRequestDTO = PatchAgentRequestDTO.builder()
-                .name("Updated Architecture Reviewer")
-                .build();
-        final PatchAgentRequest request = mock(PatchAgentRequest.class);
-        final Agent response = mock(Agent.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-
-        when(this.patchAgentApiMapper.asPatchAgentRequest(givenRequestDTO)).thenReturn(request);
-        when(this.patchAgent.execute(givenAgentId, request)).thenReturn(response);
-        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentDTO> actual = this.agentController.patchAgent(givenAgentId, givenRequestDTO);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.patchAgentApiMapper).asPatchAgentRequest(givenRequestDTO);
-        verify(this.patchAgent).execute(givenAgentId, request);
-        verify(this.agentApiMapper).asAgentDto(response);
-    }
-
-    @Test
-    void givenEmptyPatchAgentRequestDto_whenPatchAgent_thenThrowIllegalArgumentException() {
-        //given
-        final UUID givenAgentId = UUID.fromString("ebac37f0-90a2-4f6b-ab99-73f6ac5cf675");
-        final PatchAgentRequestDTO givenRequestDTO = PatchAgentRequestDTO.builder()
-                .name(null)
-                .description(null)
-                .instruction(null)
-                .build();
-
-        //when then
-        assertThatThrownBy(() -> this.agentController.patchAgent(givenAgentId, givenRequestDTO))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Patch payload cannot be empty");
-    }
-
-    @Test
-    void givenAgentId_whenActivateAgent_thenReturnOkResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-        final Agent response = mock(Agent.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-
-        when(this.activateAgent.execute(givenAgentId)).thenReturn(response);
-        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentDTO> actual = this.agentController.activateAgent(givenAgentId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.activateAgent).execute(givenAgentId);
-        verify(this.agentApiMapper).asAgentDto(response);
-    }
-
-    @Test
-    void givenAgentId_whenArchiveAgent_thenReturnOkResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
-        final Agent response = mock(Agent.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-
-        when(this.archiveAgent.execute(givenAgentId)).thenReturn(response);
-        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentDTO> actual = this.agentController.archiveAgent(givenAgentId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.archiveAgent).execute(givenAgentId);
-        verify(this.agentApiMapper).asAgentDto(response);
-    }
-
-    @Test
-    void givenChatAgentRequestDto_whenChatAgent_thenReturnOkResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
-        final ChatAgentRequestDTO givenRequestDTO = mock(ChatAgentRequestDTO.class);
+        final UUID agentId = UUID.fromString("76f023a2-cb0c-44d5-970d-053f4af51f6b");
+        final ChatAgentRequestDTO requestDto = mock(ChatAgentRequestDTO.class);
         final ChatAgentRequest request = mock(ChatAgentRequest.class);
-        final ChatAgentResponse response = mock(ChatAgentResponse.class);
-        final ChatAgentResponseDTO responseDTO = mock(ChatAgentResponseDTO.class);
+        final SubmitChatExecutionResponse response = mock(SubmitChatExecutionResponse.class);
+        final SubmitChatExecutionResponseDTO responseDto = mock(SubmitChatExecutionResponseDTO.class);
 
-        when(this.chatAgentApiMapper.asChatAgentRequest(givenRequestDTO)).thenReturn(request);
-        when(this.chatAgent.execute(givenAgentId, request)).thenReturn(response);
-        when(this.chatAgentApiMapper.asChatAgentResponseDto(response)).thenReturn(responseDTO);
+        when(this.chatAgentApiMapper.asChatAgentRequest(requestDto)).thenReturn(request);
+        when(this.submitAgentChatExecution.execute(agentId, request, "idem")).thenReturn(response);
+        when(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response)).thenReturn(responseDto);
 
         //when
-        final ResponseEntity<ChatAgentResponseDTO> actual = this.agentController.chatAgent(givenAgentId, givenRequestDTO);
+        final ResponseEntity<SubmitChatExecutionResponseDTO> actual =
+                this.agentController.submitAgentChatExecution(agentId, requestDto, "idem");
 
         //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.chatAgentApiMapper).asChatAgentRequest(givenRequestDTO);
-        verify(this.chatAgent).execute(givenAgentId, request);
-        verify(this.chatAgentApiMapper).asChatAgentResponseDto(response);
+        assertThat(actual).isEqualTo(ResponseEntity.accepted().body(responseDto));
+        verify(this.chatAgentApiMapper).asChatAgentRequest(requestDto);
+        verify(this.submitAgentChatExecution).execute(agentId, request, "idem");
+        verify(this.chatAgentApiMapper).asSubmitChatExecutionResponseDto(response);
     }
 
     @Test
-    void givenAgentId_whenGetAgentRules_thenReturnOkResponse() {
+    void givenExecutionLookupRequest_whenGetAgentChatExecution_thenReturnOkResponse() {
         //given
-        final UUID agentId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
-        final AgentRulesResponse response = mock(AgentRulesResponse.class);
-        final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
+        final UUID agentId = UUID.fromString("1f723177-ec03-4506-9011-cf0b39c97c61");
+        final UUID executionId = UUID.fromString("d67d95cb-8fcb-4a09-8f17-4ad5295a784b");
+        final UUID conversationId = UUID.fromString("3b08ad4e-13f6-4d83-ab5d-dfe04ccebe4f");
+        final ChatExecution response = mock(ChatExecution.class);
+        final ChatExecutionDTO responseDto = mock(ChatExecutionDTO.class);
 
-        when(this.getAgentRules.execute(agentId)).thenReturn(response);
-        when(this.agentRuleApiMapper.asAgentRulesResponseDto(response)).thenReturn(responseDTO);
+        when(this.getAgentChatExecution.execute(agentId, executionId, conversationId)).thenReturn(response);
+        when(this.chatAgentApiMapper.asChatExecutionDto(response)).thenReturn(responseDto);
 
         //when
-        final ResponseEntity<AgentRulesResponseDTO> actual = this.agentController.getAgentRules(agentId);
+        final ResponseEntity<ChatExecutionDTO> actual =
+                this.agentController.getAgentChatExecution(agentId, executionId, conversationId);
 
         //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.getAgentRules).execute(agentId);
-        verify(this.agentRuleApiMapper).asAgentRulesResponseDto(response);
-    }
-
-    @Test
-    void givenCreateRuleRequest_whenCreateAgentRule_thenReturnCreatedResponse() {
-        //given
-        final UUID agentId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
-        final CreateAgentRuleRequestDTO requestDTO = mock(CreateAgentRuleRequestDTO.class);
-        final CreateAgentRuleRequest request = mock(CreateAgentRuleRequest.class);
-        final AgentRule response = mock(AgentRule.class);
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-
-        when(this.agentRuleApiMapper.asCreateAgentRuleRequest(requestDTO)).thenReturn(request);
-        when(this.createAgentRule.execute(agentId, request)).thenReturn(response);
-        when(this.agentRuleApiMapper.asAgentRuleDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentRuleDTO> actual = this.agentController.createAgentRule(agentId, requestDTO);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(responseDTO));
-        verify(this.agentRuleApiMapper).asCreateAgentRuleRequest(requestDTO);
-        verify(this.createAgentRule).execute(agentId, request);
-        verify(this.agentRuleApiMapper).asAgentRuleDto(response);
-    }
-
-    @Test
-    void givenPatchRuleRequest_whenPatchAgentRule_thenReturnOkResponse() {
-        //given
-        final UUID agentId = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff");
-        final UUID ruleId = UUID.fromString("11111111-2222-3333-4444-555555555555");
-        final PatchAgentRuleRequestDTO requestDTO = mock(PatchAgentRuleRequestDTO.class);
-        final PatchAgentRuleRequest request = mock(PatchAgentRuleRequest.class);
-        final AgentRule response = mock(AgentRule.class);
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-
-        when(this.agentRuleApiMapper.asPatchAgentRuleRequest(requestDTO)).thenReturn(request);
-        when(this.patchAgentRule.execute(agentId, ruleId, request)).thenReturn(response);
-        when(this.agentRuleApiMapper.asAgentRuleDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<AgentRuleDTO> actual = this.agentController.patchAgentRule(agentId, ruleId, requestDTO);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.agentRuleApiMapper).asPatchAgentRuleRequest(requestDTO);
-        verify(this.patchAgentRule).execute(agentId, ruleId, request);
-        verify(this.agentRuleApiMapper).asAgentRuleDto(response);
-    }
-
-    @Test
-    void givenAgentAndRuleIds_whenDeleteAgentRule_thenReturnOkResponse() {
-        //given
-        final UUID agentId = UUID.fromString("22222222-3333-4444-5555-666666666666");
-        final UUID ruleId = UUID.fromString("33333333-4444-5555-6666-777777777777");
-        final DeleteAgentRuleResponse response = mock(DeleteAgentRuleResponse.class);
-        final DeleteAgentRuleResponseDTO responseDTO = mock(DeleteAgentRuleResponseDTO.class);
-
-        when(this.deleteAgentRule.execute(agentId, ruleId)).thenReturn(response);
-        when(this.agentRuleApiMapper.asDeleteAgentRuleResponseDto(response)).thenReturn(responseDTO);
-
-        //when
-        final ResponseEntity<DeleteAgentRuleResponseDTO> actual = this.agentController.deleteAgentRule(agentId, ruleId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDTO));
-        verify(this.deleteAgentRule).execute(agentId, ruleId);
-        verify(this.agentRuleApiMapper).asDeleteAgentRuleResponseDto(response);
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentChatExecution).execute(agentId, executionId, conversationId);
+        verify(this.chatAgentApiMapper).asChatExecutionDto(response);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentRuleApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/AgentRuleApiMapperTest.java
@@ -62,7 +62,7 @@ class AgentRuleApiMapperTest {
     void givenCreateAgentRuleRequestDto_whenAsCreateAgentRuleRequest_thenReturnDomainRequest() {
         //given
         final CreateAgentRuleRequestDTO given = CreateAgentRuleRequestDTO.builder()
-                .text("Always validate input")
+                .content("Always validate input")
                 .build();
         final CreateAgentRuleRequest expected = new CreateAgentRuleRequest("Always validate input");
 
@@ -77,7 +77,7 @@ class AgentRuleApiMapperTest {
     void givenPatchAgentRuleRequestDto_whenAsPatchAgentRuleRequest_thenReturnDomainRequest() {
         //given
         final PatchAgentRuleRequestDTO given = PatchAgentRuleRequestDTO.builder()
-                .text("Keep structure explicit")
+                .content("Keep structure explicit")
                 .build();
         final PatchAgentRuleRequest expected = new PatchAgentRuleRequest("Keep structure explicit");
 
@@ -115,7 +115,7 @@ class AgentRuleApiMapperTest {
     private AgentRuleDTO agentRuleDto() {
         return AgentRuleDTO.builder()
                 .id(UUID.fromString("9a79f65b-ff40-4f39-acfe-a58f089c86f7"))
-                .text("Always validate input")
+                .content("Always validate input")
                 .createdAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
                 .updatedAt(OffsetDateTime.parse("2026-04-21T10:00:00Z"))
                 .build();

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -3,15 +3,23 @@ package com.sitionix.bffssox.mapper;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationMessageDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentConversationDTO1;
 import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionFailureDTO;
+import com.app_afesox.bffssox.api_first.dto.ExecutionStatusDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.AgentConversation;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.domain.ChatAgentMessage;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.ChatExecutionFailure;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -120,7 +128,7 @@ class ChatAgentApiMapperTest {
                 this.getAgentConversationDto(
                         UUID.fromString("11111111-1111-1111-1111-111111111111"),
                         "Explain clean architecture",
-                        AgentConversationDTO.TypeEnum.DIRECT,
+                        AgentConversationDTO1.TypeEnum.DIRECT,
                         createdAt,
                         updatedAt
                 )
@@ -173,6 +181,56 @@ class ChatAgentApiMapperTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void givenSubmitChatExecutionResponse_whenAsSubmitChatExecutionResponseDto_thenReturnMappedDto() {
+        //given
+        final SubmitChatExecutionResponse given = SubmitChatExecutionResponse.builder()
+                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .state("QUEUED")
+                .createdAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
+                .idempotencyKey("idem")
+                .idempotencyReplayed(false)
+                .build();
+
+        //when
+        final SubmitChatExecutionResponseDTO actual = this.mapper.asSubmitChatExecutionResponseDto(given);
+
+        //then
+        assertThat(actual.getExecutionId()).isEqualTo(given.getExecutionId());
+        assertThat(actual.getConversationId()).isEqualTo(given.getConversationId());
+        assertThat(actual.getState()).isEqualTo(ExecutionStatusDTO.QUEUED);
+        assertThat(actual.getCreatedAt()).isEqualTo(given.getCreatedAt());
+    }
+
+    @Test
+    void givenChatExecution_whenAsChatExecutionDto_thenReturnMappedDto() {
+        //given
+        final ChatExecution given = ChatExecution.builder()
+                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .agentId(UUID.fromString("6e4e32f8-2f48-4600-9a73-bb026f98dbf4"))
+                .state("FAILED")
+                .createdAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
+                .failure(ChatExecutionFailure.builder()
+                        .failureClass("EXECUTION_ERROR")
+                        .reason("Execution failed")
+                        .retryable(true)
+                        .build())
+                .build();
+
+        //when
+        final ChatExecutionDTO actual = this.mapper.asChatExecutionDto(given);
+
+        //then
+        assertThat(actual.getState()).isEqualTo(ExecutionStatusDTO.FAILED);
+        assertThat(actual.getFailure()).isEqualTo(ChatExecutionFailureDTO.builder()
+                .failureClass(ChatExecutionFailureDTO.FailureClassEnum.EXECUTION_ERROR)
+                .reason("Execution failed")
+                .retryable(true)
+                .build());
+    }
+
     private ChatAgentRequestDTO getChatAgentRequestDto(final String message) {
         return ChatAgentRequestDTO.builder()
                 .message(message)
@@ -205,7 +263,7 @@ class ChatAgentApiMapperTest {
                 .build();
     }
 
-    private AgentConversationsResponseDTO getAgentConversationsResponseDto(final List<AgentConversationDTO> items) {
+    private AgentConversationsResponseDTO getAgentConversationsResponseDto(final List<AgentConversationDTO1> items) {
         return AgentConversationsResponseDTO.builder()
                 .items(items)
                 .build();
@@ -228,14 +286,14 @@ class ChatAgentApiMapperTest {
                 .build();
     }
 
-    private AgentConversationDTO getAgentConversationDto(
+    private AgentConversationDTO1 getAgentConversationDto(
             final UUID id,
             final String title,
-            final AgentConversationDTO.TypeEnum type,
+            final AgentConversationDTO1.TypeEnum type,
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt
     ) {
-        return AgentConversationDTO.builder()
+        return AgentConversationDTO1.builder()
                 .id(id)
                 .title(title)
                 .type(type)

--- a/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentChatExecutionImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentChatExecutionImpl.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.ChatExecution;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetAgentChatExecutionImpl implements GetAgentChatExecution {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public ChatExecution execute(final UUID agentId, final UUID executionId, final UUID conversationId) {
+        return this.agentClient.getAgentChatExecution(agentId, executionId, conversationId);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/SubmitAgentChatExecutionImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/SubmitAgentChatExecutionImpl.java
@@ -1,0 +1,20 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubmitAgentChatExecutionImpl implements SubmitAgentChatExecution {
+
+    private final AgentClient agentClient;
+
+    @Override
+    public SubmitChatExecutionResponse execute(final UUID agentId, final ChatAgentRequest request, final String idempotencyKey) {
+        return this.agentClient.submitAgentChatExecution(agentId, request, idempotencyKey);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/GetAgentChatExecutionImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/GetAgentChatExecutionImplTest.java
@@ -1,0 +1,54 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.ChatExecution;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetAgentChatExecutionImplTest {
+
+    private GetAgentChatExecution getAgentChatExecution;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.getAgentChatExecution = new GetAgentChatExecutionImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenExecutionLookupRequest_whenExecute_thenReturnClientResponse() {
+        //given
+        final UUID agentId = UUID.fromString("11ea96d9-7dc2-4810-a233-c7f8d48ece29");
+        final UUID executionId = UUID.fromString("9fcb7f34-1f0f-47f9-bdb5-607f9f4cc57f");
+        final UUID conversationId = UUID.fromString("e0887f26-f37c-4e79-a7a7-905196f9a056");
+        final ChatExecution response = mock(ChatExecution.class);
+
+        when(this.agentClient.getAgentChatExecution(agentId, executionId, conversationId)).thenReturn(response);
+
+        //when
+        final ChatExecution actual = this.getAgentChatExecution.execute(agentId, executionId, conversationId);
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentClient).getAgentChatExecution(agentId, executionId, conversationId);
+    }
+}

--- a/application/src/test/java/com/sitionix/bffssox/usecase/SubmitAgentChatExecutionImplTest.java
+++ b/application/src/test/java/com/sitionix/bffssox/usecase/SubmitAgentChatExecutionImplTest.java
@@ -1,0 +1,54 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentClient;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubmitAgentChatExecutionImplTest {
+
+    private SubmitAgentChatExecution submitAgentChatExecution;
+
+    @Mock
+    private AgentClient agentClient;
+
+    @BeforeEach
+    void setUp() {
+        this.submitAgentChatExecution = new SubmitAgentChatExecutionImpl(this.agentClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentClient);
+    }
+
+    @Test
+    void givenSubmitChatExecutionRequest_whenExecute_thenReturnClientResponse() {
+        //given
+        final UUID agentId = UUID.fromString("11ea96d9-7dc2-4810-a233-c7f8d48ece29");
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final SubmitChatExecutionResponse response = mock(SubmitChatExecutionResponse.class);
+
+        when(this.agentClient.submitAgentChatExecution(agentId, request, "key")).thenReturn(response);
+
+        //when
+        final SubmitChatExecutionResponse actual = this.submitAgentChatExecution.execute(agentId, request, "key");
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentClient).submitAgentChatExecution(agentId, request, "key");
+    }
+}

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <atmssox.api.version>0.0.11</atmssox.api.version>
+        <atmssox.api.first.version>0.0.14</atmssox.api.first.version>
     </properties>
 
     <dependencies>
@@ -44,6 +45,11 @@
             <groupId>com.afesox</groupId>
             <artifactId>app-afesox-atmssox-client-stable</artifactId>
             <version>${atmssox.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.afesox</groupId>
+            <artifactId>app-afesox-atmssox-api-first-sitionix-126-unstable</artifactId>
+            <version>${atmssox.api.first.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -1,13 +1,16 @@
 package com.sitionix.bffssox.client;
 
 import com.app_afesox.atmssox.client.api.AgentApi;
+import com.app_afesox.atmssox.client.invoker.ApiClient;
+import com.app_afesox.atmssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.atmssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
 import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
-import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
@@ -20,6 +23,7 @@ import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
@@ -27,12 +31,19 @@ import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
 import com.sitionix.bffssox.mapper.AgentRuleClientMapper;
 import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
 import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import java.util.UUID;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +62,8 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     private final PatchAgentClientMapper patchAgentClientMapper;
 
     private final ChatAgentClientMapper chatAgentClientMapper;
+
+    private final ApiClient atmssoxClient;
 
     private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
 
@@ -161,11 +174,68 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
 
     @Override
     public ChatAgentResponse chatAgent(final UUID agentId, final ChatAgentRequest request) {
-        final ChatAgentRequestDTO requestDTO = this.chatAgentClientMapper.asChatAgentRequestDto(request);
+        final com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO requestDTO = com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO.builder()
+                .conversationId(request.getConversationId())
+                .message(request.getMessage())
+                .build();
         final ChatAgentResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
                 () -> this.agentApi.chatAgent(agentId, requestDTO)
         );
         return this.chatAgentClientMapper.asChatAgentResponse(responseDTO);
+    }
+
+    @Override
+    public SubmitChatExecutionResponse submitAgentChatExecution(final UUID agentId,
+                                                                final ChatAgentRequest request,
+                                                                final String idempotencyKey) {
+        final ChatAgentRequestDTO requestDTO = this.chatAgentClientMapper.asChatAgentRequestDto(request);
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        if (idempotencyKey != null) {
+            headerParams.add("Idempotency-Key", idempotencyKey);
+        }
+        final SubmitChatExecutionResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.atmssoxClient.invokeAPI(
+                        "/api/v1/agents/{agentId}/chat/executions",
+                        HttpMethod.POST,
+                        java.util.Map.of("agentId", agentId),
+                        queryParams,
+                        requestDTO,
+                        headerParams,
+                        new LinkedMultiValueMap<>(),
+                        new LinkedMultiValueMap<>(),
+                        java.util.List.of(MediaType.APPLICATION_JSON),
+                        MediaType.APPLICATION_JSON,
+                        new String[0],
+                        new ParameterizedTypeReference<SubmitChatExecutionResponseDTO>() { }
+                ).getBody()
+        );
+        return this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO);
+    }
+
+    @Override
+    public ChatExecution getAgentChatExecution(final UUID agentId, final UUID executionId, final UUID conversationId) {
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        if (conversationId != null) {
+            queryParams.add("conversationId", conversationId.toString());
+        }
+        final ChatExecutionDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.atmssoxClient.invokeAPI(
+                        "/api/v1/agents/{agentId}/chat/executions/{executionId}",
+                        HttpMethod.GET,
+                        java.util.Map.of("agentId", agentId, "executionId", executionId),
+                        queryParams,
+                        null,
+                        new HttpHeaders(),
+                        new LinkedMultiValueMap<>(),
+                        new LinkedMultiValueMap<>(),
+                        java.util.List.of(MediaType.APPLICATION_JSON),
+                        null,
+                        new String[0],
+                        new ParameterizedTypeReference<ChatExecutionDTO>() { }
+                ).getBody()
+        );
+        return this.chatAgentClientMapper.asChatExecution(responseDTO);
     }
 
     @Override

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -4,14 +4,21 @@ import com.app_afesox.atmssox.client.dto.AgentConversationDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationMessageDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
-import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.api_first.dto.ChatAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
+import com.app_afesox.atmssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.atmssox.api_first.dto.ChatExecutionFailureDTO;
+import com.app_afesox.atmssox.api_first.dto.ExecutionStatusDTO;
+import com.app_afesox.atmssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.AgentConversation;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.ChatExecutionFailure;
 import com.sitionix.bffssox.domain.ChatAgentMessage;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.util.List;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mapper;
@@ -22,6 +29,12 @@ public interface ChatAgentClientMapper {
     ChatAgentRequestDTO asChatAgentRequestDto(ChatAgentRequest src);
 
     ChatAgentResponse asChatAgentResponse(ChatAgentResponseDTO src);
+
+    SubmitChatExecutionResponse asSubmitChatExecutionResponse(SubmitChatExecutionResponseDTO src);
+
+    ChatExecution asChatExecution(ChatExecutionDTO src);
+
+    ChatExecutionFailure asChatExecutionFailure(ChatExecutionFailureDTO src);
 
     AgentConversation asAgentConversation(AgentConversationDTO src);
 
@@ -47,6 +60,14 @@ public interface ChatAgentClientMapper {
     }
 
     default String mapAuthorType(final AgentConversationMessageDTO.AuthorTypeEnum value) {
+        return value == null ? null : value.getValue();
+    }
+
+    default String mapExecutionStatus(final ExecutionStatusDTO value) {
+        return value == null ? null : value.getValue();
+    }
+
+    default String mapFailureClass(final ChatExecutionFailureDTO.FailureClassEnum value) {
         return value == null ? null : value.getValue();
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -6,12 +6,18 @@ import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
+import com.app_afesox.atmssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.atmssox.api_first.dto.ChatExecutionFailureDTO;
+import com.app_afesox.atmssox.api_first.dto.ExecutionStatusDTO;
+import com.app_afesox.atmssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.AgentConversation;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.domain.ChatAgentMessage;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -171,6 +177,50 @@ class ChatAgentClientMapperTest {
 
         //then
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenSubmitChatExecutionResponseDto_whenAsSubmitChatExecutionResponse_thenReturnMappedDomain() {
+        //given
+        final SubmitChatExecutionResponseDTO given = SubmitChatExecutionResponseDTO.builder()
+                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .state(ExecutionStatusDTO.QUEUED)
+                .createdAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
+                .build();
+
+        //when
+        final SubmitChatExecutionResponse actual = this.mapper.asSubmitChatExecutionResponse(given);
+
+        //then
+        assertThat(actual.getExecutionId()).isEqualTo(given.getExecutionId());
+        assertThat(actual.getConversationId()).isEqualTo(given.getConversationId());
+        assertThat(actual.getState()).isEqualTo("QUEUED");
+    }
+
+    @Test
+    void givenChatExecutionDto_whenAsChatExecution_thenReturnMappedDomain() {
+        //given
+        final ChatExecutionDTO given = ChatExecutionDTO.builder()
+                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .agentId(UUID.fromString("6e4e32f8-2f48-4600-9a73-bb026f98dbf4"))
+                .state(ExecutionStatusDTO.FAILED)
+                .failure(ChatExecutionFailureDTO.builder()
+                        .failureClass(ChatExecutionFailureDTO.FailureClassEnum.EXECUTION_ERROR)
+                        .reason("Execution failed")
+                        .retryable(true)
+                        .build())
+                .build();
+
+        //when
+        final ChatExecution actual = this.mapper.asChatExecution(given);
+
+        //then
+        assertThat(actual.getState()).isEqualTo("FAILED");
+        assertThat(actual.getFailure().getFailureClass()).isEqualTo("EXECUTION_ERROR");
+        assertThat(actual.getFailure().getReason()).isEqualTo("Execution failed");
+        assertThat(actual.getFailure().getRetryable()).isTrue();
     }
 
     private ChatAgentRequest getChatAgentRequest(final String message) {

--- a/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
+++ b/domain/src/main/java/com/sitionix/bffssox/client/AgentClient.java
@@ -6,6 +6,7 @@ import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
@@ -13,6 +14,7 @@ import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.util.UUID;
 
 /**
@@ -107,6 +109,10 @@ public interface AgentClient {
      * @return assistant reply payload.
      */
     ChatAgentResponse chatAgent(UUID agentId, ChatAgentRequest request);
+
+    SubmitChatExecutionResponse submitAgentChatExecution(UUID agentId, ChatAgentRequest request, String idempotencyKey);
+
+    ChatExecution getAgentChatExecution(UUID agentId, UUID executionId, UUID conversationId);
 
     /**
      * Applies partial identity update for one automation agent.

--- a/domain/src/main/java/com/sitionix/bffssox/domain/ChatExecution.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/ChatExecution.java
@@ -1,0 +1,29 @@
+package com.sitionix.bffssox.domain;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChatExecution {
+
+    private UUID executionId;
+
+    private UUID conversationId;
+
+    private UUID agentId;
+
+    private String state;
+
+    private OffsetDateTime createdAt;
+
+    private OffsetDateTime startedAt;
+
+    private OffsetDateTime completedAt;
+
+    private ChatExecutionFailure failure;
+
+    private ChatAgentMessage assistantMessage;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/ChatExecutionFailure.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/ChatExecutionFailure.java
@@ -1,0 +1,15 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChatExecutionFailure {
+
+    private String failureClass;
+
+    private String reason;
+
+    private Boolean retryable;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/SubmitChatExecutionResponse.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/SubmitChatExecutionResponse.java
@@ -1,0 +1,23 @@
+package com.sitionix.bffssox.domain;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SubmitChatExecutionResponse {
+
+    private UUID executionId;
+
+    private UUID conversationId;
+
+    private String state;
+
+    private OffsetDateTime createdAt;
+
+    private String idempotencyKey;
+
+    private Boolean idempotencyReplayed;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentChatExecution.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentChatExecution.java
@@ -1,0 +1,9 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.ChatExecution;
+import java.util.UUID;
+
+public interface GetAgentChatExecution {
+
+    ChatExecution execute(UUID agentId, UUID executionId, UUID conversationId);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/SubmitAgentChatExecution.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/SubmitAgentChatExecution.java
@@ -1,0 +1,10 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import java.util.UUID;
+
+public interface SubmitAgentChatExecution {
+
+    SubmitChatExecutionResponse execute(UUID agentId, ChatAgentRequest request, String idempotencyKey);
+}


### PR DESCRIPTION
## Summary
- switch BFF API dependencies to SITIONIX-126 generated contracts
- replace chat submit facade with async execution submit/status endpoints in AgentController
- add domain/usecase/client mappings for execution envelope and lifecycle result
- add ATMS transport calls for new execution endpoints while keeping BFF thin facade behavior

## Verification
- ./mvnw -q -DskipTests compile
