### PR TITLE
[SITIONIX-127] - rename userMessageId to inputMessageId in BFF async chat

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.31</bffssox.api.version>
+        <bffssox.api.version>0.0.33</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-127-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.33</bffssox.api.version>
+        <bffssox.api.version>0.0.32</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-sitionix-127-unstable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -35,6 +35,7 @@ public interface ChatAgentApiMapper {
 
     @Mapping(target = "status", source = "state")
     @Mapping(target = "acceptedAt", source = "createdAt")
+    @Mapping(target = "inputMessageId", source = "inputMessageId")
     @Mapping(target = "error", ignore = true)
     SubmitChatExecutionResponseDTO asSubmitChatExecutionResponseDto(SubmitChatExecutionResponse src);
 

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -27,6 +27,7 @@ import org.mapstruct.Mapper;
 })
 public interface ChatAgentApiMapper {
 
+    @Mapping(target = "clientRequestId", source = "clientRequestId")
     ChatAgentRequest asChatAgentRequest(ChatAgentRequestDTO src);
 
     @Mapping(target = "assistantMessage", source = "reply")

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -56,6 +56,7 @@ public interface ChatAgentApiMapper {
     AgentConversationsResponseDTO asAgentConversationsResponseDto(AgentConversationsResponse src);
 
     @Mapping(target = "messages", source = "messages")
+    @Mapping(target = "executions", source = "executions")
     AgentConversationDetailsDTO asAgentConversationDetailsDto(AgentConversationDetails src);
 
     default AgentConversationDetailsDTO.TypeEnum map(final String value) {

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -175,6 +175,30 @@ class AgentControllerTest {
     }
 
     @Test
+    void givenSubmitExecutionRequest_whenSubmitAgentChatExecutionByExecutionsPath_thenDelegateToSubmitFlow() {
+        //given
+        final UUID agentId = UUID.fromString("f318a8d4-c8d5-44f2-ad4b-b3a6a900e955");
+        final ChatAgentRequestDTO requestDto = mock(ChatAgentRequestDTO.class);
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final SubmitChatExecutionResponse response = mock(SubmitChatExecutionResponse.class);
+        final SubmitChatExecutionResponseDTO responseDto = mock(SubmitChatExecutionResponseDTO.class);
+
+        when(this.chatAgentApiMapper.asChatAgentRequest(requestDto)).thenReturn(request);
+        when(this.submitAgentChatExecution.execute(agentId, request, "idem")).thenReturn(response);
+        when(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<SubmitChatExecutionResponseDTO> actual =
+                this.agentController.submitAgentChatExecutionByExecutionsPath(agentId, requestDto, "idem");
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.accepted().body(responseDto));
+        verify(this.chatAgentApiMapper).asChatAgentRequest(requestDto);
+        verify(this.submitAgentChatExecution).execute(agentId, request, "idem");
+        verify(this.chatAgentApiMapper).asSubmitChatExecutionResponseDto(response);
+    }
+
+    @Test
     void givenExecutionLookupRequest_whenGetAgentChatExecution_thenReturnOkResponse() {
         //given
         final UUID agentId = UUID.fromString("1f723177-ec03-4506-9011-cf0b39c97c61");

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -196,6 +196,7 @@ class ChatAgentApiMapperTest {
         //then
         assertThat(actual.getExecutionId()).isEqualTo(given.getExecutionId());
         assertThat(actual.getConversationId()).isEqualTo(given.getConversationId());
+        assertThat(actual.getInputMessageId()).isEqualTo(given.getInputMessageId());
         assertThat(actual.getStatus()).isEqualTo(ExecutionStatusDTO.ACCEPTED);
         assertThat(actual.getAcceptedAt()).isEqualTo(given.getCreatedAt());
     }
@@ -365,6 +366,7 @@ class ChatAgentApiMapperTest {
         return SubmitChatExecutionResponse.builder()
                 .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
                 .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .inputMessageId(UUID.fromString("f0beec7e-5c98-48b9-ae82-0a6952576a7a"))
                 .state("QUEUED")
                 .createdAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
                 .idempotencyKey("idem")

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -161,7 +161,8 @@ class ChatAgentApiMapperTest {
                         "agent-1",
                         "Clean architecture separates business logic.",
                         createdAt
-                ))
+                )),
+                List.of(this.getFailedChatExecution())
         );
         final AgentConversationDetailsDTO expected = this.getAgentConversationDetailsDto(
                 UUID.fromString("11111111-1111-1111-1111-111111111111"),
@@ -175,7 +176,8 @@ class ChatAgentApiMapperTest {
                         "agent-1",
                         "Clean architecture separates business logic.",
                         createdAt
-                ))
+                )),
+                List.of(this.mapper.asChatExecutionDto(this.getFailedChatExecution()))
         );
 
         //when
@@ -298,7 +300,8 @@ class ChatAgentApiMapperTest {
             final String type,
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
-            final List<ChatAgentMessage> messages
+            final List<ChatAgentMessage> messages,
+            final List<ChatExecution> executions
     ) {
         return AgentConversationDetails.builder()
                 .id(id)
@@ -308,6 +311,7 @@ class ChatAgentApiMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
+                .executions(executions)
                 .build();
     }
 
@@ -317,7 +321,8 @@ class ChatAgentApiMapperTest {
             final AgentConversationDetailsDTO.TypeEnum type,
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
-            final List<AgentConversationMessageDTO> messages
+            final List<AgentConversationMessageDTO> messages,
+            final List<ChatExecutionDTO> executions
     ) {
         return AgentConversationDetailsDTO.builder()
                 .id(id)
@@ -327,6 +332,7 @@ class ChatAgentApiMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
+                .executions(executions)
                 .build();
     }
 

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -46,8 +46,9 @@ class ChatAgentApiMapperTest {
     @Test
     void givenChatAgentRequestDto_whenAsChatAgentRequest_thenReturnChatAgentRequest() {
         //given
-        final ChatAgentRequestDTO given = this.getChatAgentRequestDto("Explain clean architecture");
-        final ChatAgentRequest expected = this.getChatAgentRequest("Explain clean architecture");
+        final UUID clientRequestId = UUID.fromString("742261a5-e89f-4153-96f3-f1275d2dd4e4");
+        final ChatAgentRequestDTO given = this.getChatAgentRequestDto(clientRequestId, "Explain clean architecture");
+        final ChatAgentRequest expected = this.getChatAgentRequest(clientRequestId, "Explain clean architecture");
 
         //when
         final ChatAgentRequest actual = this.mapper.asChatAgentRequest(given);
@@ -216,14 +217,16 @@ class ChatAgentApiMapperTest {
                 .build());
     }
 
-    private ChatAgentRequestDTO getChatAgentRequestDto(final String message) {
+    private ChatAgentRequestDTO getChatAgentRequestDto(final UUID clientRequestId, final String message) {
         return ChatAgentRequestDTO.builder()
+                .clientRequestId(clientRequestId)
                 .message(message)
                 .build();
     }
 
-    private ChatAgentRequest getChatAgentRequest(final String message) {
+    private ChatAgentRequest getChatAgentRequest(final UUID clientRequestId, final String message) {
         return ChatAgentRequest.builder()
+                .clientRequestId(clientRequestId)
                 .message(message)
                 .build();
     }

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentConversationControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentConversationControllerIT.java
@@ -151,6 +151,26 @@ class AgentConversationControllerIT {
     }
 
     @Test
+    @DisplayName("given valid user token when chat then return accepted with input message id")
+    void givenValidUserToken_whenChat_thenReturnAcceptedWithInputMessageId() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_CHAT_AGENT)
+                .pathPattern(WireMockPathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_CHAT_AGENT)
+                .withPathParameters(PathParams.create()
+                        .add("agentId", "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
     @DisplayName("given blank message when chat then return bad request")
     void givenBlankMessage_whenChat_thenReturnBadRequest() {
         //given

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitChatExecutionNewConversation.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitChatExecutionNewConversation.json
@@ -1,6 +1,7 @@
 {
   "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
   "conversationId": "11111111-1111-1111-1111-111111111111",
+  "inputMessageId": "22222222-2222-2222-2222-222222222222",
   "status": "ACCEPTED",
   "acceptedAt": "2026-04-29T10:00:00Z"
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitChatExecutionNewConversation.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitChatExecutionNewConversation.json
@@ -1,6 +1,7 @@
 {
   "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
   "conversationId": "11111111-1111-1111-1111-111111111111",
+  "inputMessageId": "22222222-2222-2222-2222-222222222222",
   "status": "ACCEPTED",
   "acceptedAt": "2026-04-29T10:00:00Z"
 }

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.19</atmssox.api.version>
+        <atmssox.api.version>0.0.18</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-sitionix-127-unstable</artifactId>
+            <artifactId>app-afesox-atmssox-client-stable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.14</atmssox.api.version>
+        <atmssox.api.version>0.0.19</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-127-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -4,8 +4,8 @@ import com.app_afesox.atmssox.client.dto.AgentConversationDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationMessageDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentExecutionDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
 import com.app_afesox.atmssox.client.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.AgentConversation;
@@ -30,10 +30,12 @@ public interface ChatAgentClientMapper {
     @Mapping(target = "clientRequestId", source = "clientRequestId")
     ChatAgentRequestDTO asChatAgentRequestDto(ChatAgentRequest src);
 
-    ChatAgentResponse asChatAgentResponse(ChatAgentResponseDTO src);
+    @Mapping(target = "reply", source = "assistantMessage")
+    ChatAgentResponse asChatAgentResponse(ChatAgentExecutionDTO src);
 
     @Mapping(target = "state", source = "status")
     @Mapping(target = "createdAt", source = "acceptedAt")
+    @Mapping(target = "inputMessageId", source = "inputMessageId")
     SubmitChatExecutionResponse asSubmitChatExecutionResponse(SubmitChatExecutionResponseDTO src);
 
     @Mapping(target = "state", source = "status")

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -56,6 +56,7 @@ public interface ChatAgentClientMapper {
 
     @Mapping(target = "type", source = "type")
     @Mapping(target = "messages", source = "messages")
+    @Mapping(target = "executions", source = "executions")
     AgentConversationDetails asAgentConversationDetails(AgentConversationDetailsDTO src);
 
     default String map(final AgentConversationDetailsDTO.TypeEnum value) {

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -27,6 +27,7 @@ import org.mapstruct.Mapper;
 })
 public interface ChatAgentClientMapper {
 
+    @Mapping(target = "clientRequestId", source = "clientRequestId")
     ChatAgentRequestDTO asChatAgentRequestDto(ChatAgentRequest src);
 
     ChatAgentResponse asChatAgentResponse(ChatAgentResponseDTO src);

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -50,6 +50,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -356,8 +358,12 @@ class AgentClientImplTest {
     void givenChatAgentRequest_whenSubmitAgentChatExecution_thenReturnExecutionAck() {
         //given
         final UUID givenAgentId = UUID.fromString("7ac2f8c1-3d66-4cb4-95d9-27df5c66bf20");
+        final UUID clientRequestId = UUID.fromString("8ecef151-3f6a-46a8-a9a4-1f61f65b6f09");
         final ChatAgentRequest request = mock(ChatAgentRequest.class);
-        final ChatAgentRequestDTO requestDTO = mock(ChatAgentRequestDTO.class);
+        final ChatAgentRequestDTO requestDTO = ChatAgentRequestDTO.builder()
+                .clientRequestId(clientRequestId)
+                .message("message")
+                .build();
         final SubmitChatExecutionResponseDTO responseDTO = mock(SubmitChatExecutionResponseDTO.class);
         final SubmitChatExecutionResponse expected = mock(SubmitChatExecutionResponse.class);
 
@@ -376,7 +382,11 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(expected);
         verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, "idem-key");
+        verify(this.agentApi).submitAgentChatExecutionByExecutionsPath(
+                eq(givenAgentId),
+                argThat(dto -> dto != null && clientRequestId.equals(dto.getClientRequestId())),
+                eq("idem-key")
+        );
         verify(this.chatAgentClientMapper).asSubmitChatExecutionResponse(responseDTO);
     }
 

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -2,11 +2,10 @@ package com.sitionix.bffssox.mapper;
 
 import com.app_afesox.atmssox.client.dto.AgentConversationMessageDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationDTO;
-import com.app_afesox.atmssox.client.dto.AgentConversationDTO1;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentExecutionDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.ChatAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
 import com.app_afesox.atmssox.client.dto.ChatExecutionFailureDTO;
 import com.app_afesox.atmssox.client.dto.ExecutionStatusDTO;
@@ -66,11 +65,11 @@ class ChatAgentClientMapperTest {
     }
 
     @Test
-    void givenChatAgentResponseDto_whenAsChatAgentResponse_thenReturnChatAgentResponse() {
+    void givenChatAgentExecutionDto_whenAsChatAgentResponse_thenReturnChatAgentResponse() {
         //given
         final UUID conversationId = UUID.fromString("11111111-1111-1111-1111-111111111111");
         final OffsetDateTime createdAt = OffsetDateTime.parse("2026-04-21T10:01:00Z");
-        final ChatAgentResponseDTO given = this.getChatAgentResponseDto(
+        final ChatAgentExecutionDTO given = this.getChatAgentExecutionDto(
                 conversationId,
                 this.getAgentConversationMessageDto(
                         UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
@@ -82,7 +81,13 @@ class ChatAgentClientMapperTest {
         );
         final ChatAgentResponse expected = this.getChatAgentResponse(
                 conversationId,
-                null
+                this.getChatAgentMessage(
+                        UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                        "AGENT",
+                        "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+                        "SOLID is a set of design principles.",
+                        createdAt
+                )
         );
 
         //when
@@ -90,7 +95,6 @@ class ChatAgentClientMapperTest {
 
         //then
         assertThat(actual).isEqualTo(expected);
-        assertThat(actual.getReply()).isNull();
     }
 
     @Test
@@ -106,9 +110,9 @@ class ChatAgentClientMapperTest {
     }
 
     @Test
-    void givenNullChatAgentResponseDto_whenAsChatAgentResponse_thenReturnNull() {
+    void givenNullChatAgentExecutionDto_whenAsChatAgentResponse_thenReturnNull() {
         //given
-        final ChatAgentResponseDTO given = null;
+        final ChatAgentExecutionDTO given = null;
 
         //when
         final ChatAgentResponse actual = this.mapper.asChatAgentResponse(given);
@@ -126,7 +130,7 @@ class ChatAgentClientMapperTest {
                 this.getAgentConversationDto(
                         UUID.fromString("11111111-1111-1111-1111-111111111111"),
                         "Explain clean architecture",
-                        AgentConversationDTO1.TypeEnum.DIRECT,
+                        AgentConversationDTO.TypeEnum.DIRECT,
                         createdAt,
                         updatedAt
                 )
@@ -235,9 +239,10 @@ class ChatAgentClientMapperTest {
                 .build();
     }
 
-    private ChatAgentResponseDTO getChatAgentResponseDto(final UUID conversationId, final AgentConversationMessageDTO reply) {
-        return ChatAgentResponseDTO.builder()
+    private ChatAgentExecutionDTO getChatAgentExecutionDto(final UUID conversationId, final AgentConversationMessageDTO reply) {
+        return ChatAgentExecutionDTO.builder()
                 .conversationId(conversationId)
+                .assistantMessage(reply)
                 .build();
     }
 
@@ -248,7 +253,7 @@ class ChatAgentClientMapperTest {
                 .build();
     }
 
-    private AgentConversationsResponseDTO getAgentConversationsResponseDto(final List<AgentConversationDTO1> items) {
+    private AgentConversationsResponseDTO getAgentConversationsResponseDto(final List<AgentConversationDTO> items) {
         return AgentConversationsResponseDTO.builder()
                 .items(items)
                 .build();
@@ -277,14 +282,14 @@ class ChatAgentClientMapperTest {
                 .build();
     }
 
-    private AgentConversationDTO1 getAgentConversationDto(
+    private AgentConversationDTO getAgentConversationDto(
             final UUID id,
             final String title,
-            final AgentConversationDTO1.TypeEnum type,
+            final AgentConversationDTO.TypeEnum type,
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt
     ) {
-        return AgentConversationDTO1.builder()
+        return AgentConversationDTO.builder()
                 .id(id)
                 .title(title)
                 .type(type)
@@ -368,6 +373,7 @@ class ChatAgentClientMapperTest {
         return SubmitChatExecutionResponseDTO.builder()
                 .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
                 .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .inputMessageId(UUID.fromString("f0beec7e-5c98-48b9-ae82-0a6952576a7a"))
                 .status(ExecutionStatusDTO.ACCEPTED)
                 .acceptedAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
                 .idempotencyKey("key-1")
@@ -379,6 +385,7 @@ class ChatAgentClientMapperTest {
         return SubmitChatExecutionResponse.builder()
                 .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
                 .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .inputMessageId(UUID.fromString("f0beec7e-5c98-48b9-ae82-0a6952576a7a"))
                 .state("QUEUED")
                 .createdAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
                 .idempotencyKey("key-1")

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -156,6 +156,9 @@ class ChatAgentClientMapperTest {
     void givenAgentConversationDetailsDto_whenAsAgentConversationDetails_thenReturnMappedDetails() {
         //given
         final OffsetDateTime createdAt = OffsetDateTime.parse("2026-04-21T10:01:00Z");
+        when(this.chatExecutionStatusClientMapper.mapExecutionStatus(ExecutionStatusDTO.FAILED)).thenReturn("FAILED");
+        when(this.chatExecutionFailureClientMapper.asChatExecutionFailure(this.getChatExecutionFailureDto()))
+                .thenReturn(this.getChatExecutionFailure("EXECUTION_ERROR", "Execution failed", true));
         final AgentConversationDetailsDTO given = this.getAgentConversationDetailsDto(
                 UUID.fromString("11111111-1111-1111-1111-111111111111"),
                 "Explain clean architecture",
@@ -168,7 +171,8 @@ class ChatAgentClientMapperTest {
                         "agent-1",
                         "Clean architecture separates business logic.",
                         createdAt
-                ))
+                )),
+                List.of(this.getFailedChatExecutionDto())
         );
         final AgentConversationDetails expected = this.getAgentConversationDetails(
                 UUID.fromString("11111111-1111-1111-1111-111111111111"),
@@ -182,7 +186,8 @@ class ChatAgentClientMapperTest {
                         "agent-1",
                         "Clean architecture separates business logic.",
                         createdAt
-                ))
+                )),
+                List.of(this.getFailedChatExecution())
         );
 
         //when
@@ -305,7 +310,8 @@ class ChatAgentClientMapperTest {
             final AgentConversationDetailsDTO.TypeEnum type,
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
-            final List<AgentConversationMessageDTO> messages
+            final List<AgentConversationMessageDTO> messages,
+            final List<ChatExecutionDTO> executions
     ) {
         return AgentConversationDetailsDTO.builder()
                 .id(id)
@@ -315,6 +321,7 @@ class ChatAgentClientMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
+                .executions(executions)
                 .build();
     }
 
@@ -324,7 +331,8 @@ class ChatAgentClientMapperTest {
             final String type,
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
-            final List<ChatAgentMessage> messages
+            final List<ChatAgentMessage> messages,
+            final List<ChatExecution> executions
     ) {
         return AgentConversationDetails.builder()
                 .id(id)
@@ -334,6 +342,7 @@ class ChatAgentClientMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
+                .executions(executions)
                 .build();
     }
 
@@ -399,6 +408,15 @@ class ChatAgentClientMapperTest {
                 .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
                 .status(ExecutionStatusDTO.FAILED)
                 .error(this.getChatExecutionFailureDto())
+                .build();
+    }
+
+    private ChatExecution getFailedChatExecution() {
+        return ChatExecution.builder()
+                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .state("FAILED")
+                .failure(this.getChatExecutionFailure("EXECUTION_ERROR", "Execution failed", true))
                 .build();
     }
 

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -54,8 +54,9 @@ class ChatAgentClientMapperTest {
     @Test
     void givenChatAgentRequest_whenAsChatAgentRequestDto_thenReturnChatAgentRequestDto() {
         //given
-        final ChatAgentRequest given = this.getChatAgentRequest("Explain SOLID");
-        final ChatAgentRequestDTO expected = this.getChatAgentRequestDto("Explain SOLID");
+        final UUID clientRequestId = UUID.fromString("6ba1153e-a336-42a1-92ea-3203be095aa2");
+        final ChatAgentRequest given = this.getChatAgentRequest(clientRequestId, "Explain SOLID");
+        final ChatAgentRequestDTO expected = this.getChatAgentRequestDto(clientRequestId, "Explain SOLID");
 
         //when
         final ChatAgentRequestDTO actual = this.mapper.asChatAgentRequestDto(given);
@@ -220,14 +221,16 @@ class ChatAgentClientMapperTest {
         assertThat(actual.getFailure().getRetryable()).isTrue();
     }
 
-    private ChatAgentRequest getChatAgentRequest(final String message) {
+    private ChatAgentRequest getChatAgentRequest(final UUID clientRequestId, final String message) {
         return ChatAgentRequest.builder()
+                .clientRequestId(clientRequestId)
                 .message(message)
                 .build();
     }
 
-    private ChatAgentRequestDTO getChatAgentRequestDto(final String message) {
+    private ChatAgentRequestDTO getChatAgentRequestDto(final UUID clientRequestId, final String message) {
         return ChatAgentRequestDTO.builder()
+                .clientRequestId(clientRequestId)
                 .message(message)
                 .build();
     }

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentConversationDetails.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentConversationDetails.java
@@ -23,4 +23,6 @@ public class AgentConversationDetails {
     private OffsetDateTime lastMessageAt;
 
     private List<ChatAgentMessage> messages;
+
+    private List<ChatExecution> executions;
 }

--- a/domain/src/main/java/com/sitionix/bffssox/domain/ChatAgentRequest.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/ChatAgentRequest.java
@@ -8,6 +8,8 @@ import lombok.Data;
 @Builder
 public class ChatAgentRequest {
 
+    private UUID clientRequestId;
+
     private UUID conversationId;
 
     private String message;

--- a/domain/src/main/java/com/sitionix/bffssox/domain/SubmitChatExecutionResponse.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/SubmitChatExecutionResponse.java
@@ -13,6 +13,8 @@ public class SubmitChatExecutionResponse {
 
     private UUID conversationId;
 
+    private UUID inputMessageId;
+
     private String state;
 
     private OffsetDateTime createdAt;


### PR DESCRIPTION
## Summary
- add clientRequestId to domain ChatAgentRequest
- propagate clientRequestId in API and ATM client mappers
- extend unit tests and controller delegation test for async submit flow

## Verification
- mvn -pl api-rest,clients/client-atmssox -am -DfailIfNoTests=false -Dtest=ChatAgentApiMapperTest,ChatAgentClientMapperTest,AgentClientImplTest,AgentControllerTest test
- mvn -pl boot -am -Dtest=AgentConversationControllerIT -DfailIfNoTests=false test