### PR TITLE
[SITIONIX-131] - split bff agent controllers and clients

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-sitionix-131-unstable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.35</bffssox.api.version>
+        <bffssox.api.version>0.0.36</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-131-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentChatController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentChatController.java
@@ -1,0 +1,54 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.api.AgentChatApi;
+import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
+import com.sitionix.bffssox.usecase.GetAgentChatExecution;
+import com.sitionix.bffssox.usecase.SubmitAgentChatExecution;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AgentChatController implements AgentChatApi {
+
+    private final ChatAgentApiMapper chatAgentApiMapper;
+    private final SubmitAgentChatExecution submitAgentChatExecution;
+    private final GetAgentChatExecution getAgentChatExecution;
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<SubmitChatExecutionResponseDTO> submitAgentChatExecution(final UUID agentId,
+                                                                                    @Valid final ChatAgentRequestDTO chatAgentRequestDTO,
+                                                                                    final String idempotencyKey) {
+        final ChatAgentRequest request = this.chatAgentApiMapper.asChatAgentRequest(chatAgentRequestDTO);
+        final SubmitChatExecutionResponse response = this.submitAgentChatExecution.execute(agentId, request, idempotencyKey);
+        return ResponseEntity.accepted().body(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<SubmitChatExecutionResponseDTO> submitAgentChatExecutionByExecutionsPath(final UUID agentId,
+                                                                                                    @Valid final ChatAgentRequestDTO chatAgentRequestDTO,
+                                                                                                    final String idempotencyKey) {
+        return this.submitAgentChatExecution(agentId, chatAgentRequestDTO, idempotencyKey);
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ChatExecutionDTO> getAgentChatExecution(final UUID agentId,
+                                                                  final UUID executionId,
+                                                                  final UUID conversationId) {
+        final ChatExecution response = this.getAgentChatExecution.execute(agentId, executionId, conversationId);
+        return ResponseEntity.ok(this.chatAgentApiMapper.asChatExecutionDto(response));
+    }
+}

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentController.java
@@ -1,65 +1,24 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.api.AgentApi;
-import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
-import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
-import com.sitionix.bffssox.domain.AgentConversationDetails;
-import com.sitionix.bffssox.domain.AgentConversationsResponse;
-import com.sitionix.bffssox.domain.AgentProject;
-import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
-import com.sitionix.bffssox.domain.AgentRule;
-import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
-import com.sitionix.bffssox.domain.ChatExecution;
-import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
-import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
-import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
-import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
-import com.sitionix.bffssox.mapper.AgentRuleApiMapper;
-import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
-import com.sitionix.bffssox.mapper.CreateAgentProjectApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.ActivateAgent;
 import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
-import com.sitionix.bffssox.usecase.CreateAgentProject;
-import com.sitionix.bffssox.usecase.CreateAgentRule;
-import com.sitionix.bffssox.usecase.DeleteAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgent;
-import com.sitionix.bffssox.usecase.DeleteAgentConversation;
 import com.sitionix.bffssox.usecase.GetAgent;
-import com.sitionix.bffssox.usecase.GetAgentChatExecution;
-import com.sitionix.bffssox.usecase.GetAgentConversation;
-import com.sitionix.bffssox.usecase.GetAgentConversations;
 import com.sitionix.bffssox.usecase.GetAgents;
-import com.sitionix.bffssox.usecase.GetAgentProjects;
-import com.sitionix.bffssox.usecase.GetAgentProject;
-import com.sitionix.bffssox.usecase.GetAgentRules;
-import com.sitionix.bffssox.usecase.PatchAgentRule;
 import com.sitionix.bffssox.usecase.PatchAgent;
 import com.sitionix.bffssox.usecase.RestoreAgent;
-import com.sitionix.bffssox.usecase.SubmitAgentChatExecution;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -73,69 +32,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class AgentController implements AgentApi {
 
     private final CreateAgentApiMapper createAgentApiMapper;
-    private final CreateAgentProjectApiMapper createAgentProjectApiMapper;
-
     private final AgentApiMapper agentApiMapper;
-
-    private final AgentRuleApiMapper agentRuleApiMapper;
-
     private final CreateAgent createAgent;
-    private final CreateAgentProject createAgentProject;
-
     private final PatchAgentApiMapper patchAgentApiMapper;
-
     private final PatchAgent patchAgent;
-
-    private final ChatAgentApiMapper chatAgentApiMapper;
-
-    private final SubmitAgentChatExecution submitAgentChatExecution;
-
-    private final GetAgentChatExecution getAgentChatExecution;
-
     private final GetAgents getAgents;
-    private final GetAgentProjects getAgentProjects;
-    private final GetAgentProject getAgentProject;
-
     private final GetAgent getAgent;
-
-    private final GetAgentConversations getAgentConversations;
-
-    private final GetAgentConversation getAgentConversation;
-
     private final ActivateAgent activateAgent;
-
     private final ArchiveAgent archiveAgent;
-
     private final RestoreAgent restoreAgent;
-
     private final DeleteAgent deleteAgent;
-
-    private final GetAgentRules getAgentRules;
-
-    private final CreateAgentRule createAgentRule;
-
-    private final PatchAgentRule patchAgentRule;
-
-    private final DeleteAgentRule deleteAgentRule;
-
-    private final DeleteAgentConversation deleteAgentConversation;
 
     @Override
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<AgentDTO> createAgent(@Valid final CreateAgentRequestDTO createAgentRequestDTO) {
         final CreateAgentRequest request = this.createAgentApiMapper.asCreateAgentRequest(createAgentRequestDTO);
         final Agent response = this.createAgent.execute(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(this.agentApiMapper.asAgentDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentProjectDTO> createAgentProject(@Valid final CreateAgentProjectRequestDTO createAgentProjectRequestDTO) {
-        final CreateAgentProjectRequest request = this.createAgentProjectApiMapper.asCreateAgentProjectRequest(createAgentProjectRequestDTO);
-        final AgentProject response = this.createAgentProject.execute(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(this.agentApiMapper.asAgentProjectDto(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(this.agentApiMapper.asAgentDto(response));
     }
 
     @Override
@@ -147,37 +60,9 @@ public class AgentController implements AgentApi {
 
     @Override
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentProjectsPageResponseDTO> getAgentProjects(final Integer page, final Integer size) {
-        final AgentProjectsPageResponse response = this.getAgentProjects.execute(page, size);
-        return ResponseEntity.ok(this.agentApiMapper.asAgentProjectsPageResponseDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentProjectDTO> getAgentProject(final UUID projectId) {
-        final AgentProject response = this.getAgentProject.execute(projectId);
-        return ResponseEntity.ok(this.agentApiMapper.asAgentProjectDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<AgentDTO> getAgent(final UUID agentId) {
         final Agent response = this.getAgent.execute(agentId);
         return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentConversationsResponseDTO> getAgentConversations(final UUID agentId) {
-        final AgentConversationsResponse response = this.getAgentConversations.execute(agentId);
-        return ResponseEntity.ok(this.chatAgentApiMapper.asAgentConversationsResponseDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentConversationDetailsDTO> getAgentConversation(final UUID conversationId) {
-        final AgentConversationDetails response = this.getAgentConversation.execute(conversationId);
-        return ResponseEntity.ok(this.chatAgentApiMapper.asAgentConversationDetailsDto(response));
     }
 
     @Override
@@ -206,84 +91,6 @@ public class AgentController implements AgentApi {
     public ResponseEntity<AgentDTO> deleteAgent(final UUID agentId) {
         final Agent response = this.deleteAgent.execute(agentId);
         return ResponseEntity.ok(this.agentApiMapper.asAgentDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Void> deleteAgentConversation(final UUID conversationId) {
-        this.deleteAgentConversation.execute(conversationId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentRulesResponseDTO> getAgentRules(final UUID agentId,
-                                                               final AgentRuleStatusDTO status,
-                                                               final AgentRuleAuthorTypeDTO authorType) {
-        final AgentRulesResponse response = this.getAgentRules.execute(
-                agentId,
-                this.agentRuleApiMapper.asGetAgentRulesQuery(status, authorType)
-        );
-        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRulesResponseDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentRuleDTO> createAgentRule(final UUID agentId, @Valid final CreateAgentRuleRequestDTO createAgentRuleRequestDTO) {
-        final CreateAgentRuleRequest request = this.agentRuleApiMapper.asCreateAgentRuleRequest(createAgentRuleRequestDTO);
-        final AgentRule response = this.createAgentRule.execute(agentId, request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(this.agentRuleApiMapper.asAgentRuleDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<AgentRuleDTO> patchAgentRule(final UUID agentId,
-                                                       final UUID ruleId,
-                                                       @Valid final PatchAgentRuleRequestDTO patchAgentRuleRequestDTO) {
-        final AgentRule response = this.patchAgentRule.execute(
-                agentId,
-                ruleId,
-                this.agentRuleApiMapper.asPatchAgentRuleRequest(patchAgentRuleRequestDTO)
-        );
-        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<DeleteAgentRuleResponseDTO> deleteAgentRule(final UUID agentId, final UUID ruleId) {
-        final DeleteAgentRuleResponse response = this.deleteAgentRule.execute(agentId, ruleId);
-        return ResponseEntity.ok(this.agentRuleApiMapper.asDeleteAgentRuleResponseDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<SubmitChatExecutionResponseDTO> submitAgentChatExecution(final UUID agentId,
-                                                                                    @Valid final ChatAgentRequestDTO chatAgentRequestDTO,
-                                                                                    final String idempotencyKey) {
-        final SubmitChatExecutionResponse response = this.submitAgentChatExecution.execute(
-                agentId,
-                this.chatAgentApiMapper.asChatAgentRequest(chatAgentRequestDTO),
-                idempotencyKey
-        );
-        return ResponseEntity.accepted().body(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response));
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<SubmitChatExecutionResponseDTO> submitAgentChatExecutionByExecutionsPath(final UUID agentId,
-                                                                                                    @Valid final ChatAgentRequestDTO chatAgentRequestDTO,
-                                                                                                    final String idempotencyKey) {
-        return this.submitAgentChatExecution(agentId, chatAgentRequestDTO, idempotencyKey);
-    }
-
-    @Override
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ChatExecutionDTO> getAgentChatExecution(final UUID agentId,
-                                                                  final UUID executionId,
-                                                                  final UUID conversationId) {
-        final ChatExecution response = this.getAgentChatExecution.execute(agentId, executionId, conversationId);
-        return ResponseEntity.ok(this.chatAgentApiMapper.asChatExecutionDto(response));
     }
 
     @Override

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentConversationController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentConversationController.java
@@ -1,0 +1,47 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.api.AgentConversationApi;
+import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
+import com.sitionix.bffssox.domain.AgentConversationDetails;
+import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
+import com.sitionix.bffssox.usecase.DeleteAgentConversation;
+import com.sitionix.bffssox.usecase.GetAgentConversation;
+import com.sitionix.bffssox.usecase.GetAgentConversations;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AgentConversationController implements AgentConversationApi {
+
+    private final ChatAgentApiMapper chatAgentApiMapper;
+    private final GetAgentConversations getAgentConversations;
+    private final GetAgentConversation getAgentConversation;
+    private final DeleteAgentConversation deleteAgentConversation;
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentConversationsResponseDTO> getAgentConversations(final UUID agentId) {
+        final AgentConversationsResponse response = this.getAgentConversations.execute(agentId);
+        return ResponseEntity.ok(this.chatAgentApiMapper.asAgentConversationsResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentConversationDetailsDTO> getAgentConversation(final UUID conversationId) {
+        final AgentConversationDetails response = this.getAgentConversation.execute(conversationId);
+        return ResponseEntity.ok(this.chatAgentApiMapper.asAgentConversationDetailsDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteAgentConversation(final UUID conversationId) {
+        this.deleteAgentConversation.execute(conversationId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentProjectController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentProjectController.java
@@ -1,0 +1,54 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.api.AgentProjectApi;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
+import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
+import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
+import com.sitionix.bffssox.mapper.AgentApiMapper;
+import com.sitionix.bffssox.mapper.CreateAgentProjectApiMapper;
+import com.sitionix.bffssox.usecase.CreateAgentProject;
+import com.sitionix.bffssox.usecase.GetAgentProject;
+import com.sitionix.bffssox.usecase.GetAgentProjects;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AgentProjectController implements AgentProjectApi {
+
+    private final CreateAgentProjectApiMapper createAgentProjectApiMapper;
+    private final AgentApiMapper agentApiMapper;
+    private final CreateAgentProject createAgentProject;
+    private final GetAgentProjects getAgentProjects;
+    private final GetAgentProject getAgentProject;
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentProjectDTO> createAgentProject(@Valid final CreateAgentProjectRequestDTO createAgentProjectRequestDTO) {
+        final CreateAgentProjectRequest request = this.createAgentProjectApiMapper.asCreateAgentProjectRequest(createAgentProjectRequestDTO);
+        final AgentProject response = this.createAgentProject.execute(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(this.agentApiMapper.asAgentProjectDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentProjectsPageResponseDTO> getAgentProjects(final Integer page, final Integer size) {
+        final AgentProjectsPageResponse response = this.getAgentProjects.execute(page, size);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentProjectsPageResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentProjectDTO> getAgentProject(final UUID projectId) {
+        final AgentProject response = this.getAgentProject.execute(projectId);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentProjectDto(response));
+    }
+}

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentRuleController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentRuleController.java
@@ -1,0 +1,91 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.api.AgentRuleApi;
+import com.app_afesox.bffssox.api_first.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleAuthorTypeDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AgentRule;
+import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
+import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.mapper.AgentRuleApiMapper;
+import com.sitionix.bffssox.usecase.CreateAgentRule;
+import com.sitionix.bffssox.usecase.DeleteAgentRule;
+import com.sitionix.bffssox.usecase.GetAgentRules;
+import com.sitionix.bffssox.usecase.PatchAgentRule;
+import com.sitionix.bffssox.usecase.RejectAgentRule;
+import com.sitionix.bffssox.usecase.AcceptAgentRule;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AgentRuleController implements AgentRuleApi {
+
+    private final AgentRuleApiMapper agentRuleApiMapper;
+    private final GetAgentRules getAgentRules;
+    private final CreateAgentRule createAgentRule;
+    private final PatchAgentRule patchAgentRule;
+    private final DeleteAgentRule deleteAgentRule;
+    private final AcceptAgentRule acceptAgentRule;
+    private final RejectAgentRule rejectAgentRule;
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRulesResponseDTO> getAgentRules(final UUID agentId,
+                                                               final AgentRuleStatusDTO status,
+                                                               final AgentRuleAuthorTypeDTO authorType) {
+        final AgentRulesResponse response = this.getAgentRules.execute(agentId, this.agentRuleApiMapper.asGetAgentRulesQuery(status, authorType));
+        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRulesResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRuleDTO> createAgentRule(final UUID agentId, @Valid final CreateAgentRuleRequestDTO createAgentRuleRequestDTO) {
+        final CreateAgentRuleRequest request = this.agentRuleApiMapper.asCreateAgentRuleRequest(createAgentRuleRequestDTO);
+        final AgentRule response = this.createAgentRule.execute(agentId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(this.agentRuleApiMapper.asAgentRuleDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRuleDTO> patchAgentRule(final UUID agentId,
+                                                       final UUID ruleId,
+                                                       @Valid final PatchAgentRuleRequestDTO patchAgentRuleRequestDTO) {
+        final AgentRule response = this.patchAgentRule.execute(agentId, ruleId, this.agentRuleApiMapper.asPatchAgentRuleRequest(patchAgentRuleRequestDTO));
+        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<DeleteAgentRuleResponseDTO> deleteAgentRule(final UUID agentId, final UUID ruleId) {
+        final DeleteAgentRuleResponse response = this.deleteAgentRule.execute(agentId, ruleId);
+        return ResponseEntity.ok(this.agentRuleApiMapper.asDeleteAgentRuleResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRuleDTO> acceptAgentRule(final UUID agentId,
+                                                        final UUID ruleId,
+                                                        @Valid final AcceptAgentRuleRequestDTO acceptAgentRuleRequestDTO) {
+        final AgentRule response = this.acceptAgentRule.execute(agentId, ruleId, this.agentRuleApiMapper.asAcceptAgentRuleRequest(acceptAgentRuleRequestDTO));
+        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentRuleDTO> rejectAgentRule(final UUID agentId, final UUID ruleId) {
+        final AgentRule response = this.rejectAgentRule.execute(agentId, ruleId);
+        return ResponseEntity.ok(this.agentRuleApiMapper.asAgentRuleDto(response));
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentChatControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentChatControllerTest.java
@@ -1,0 +1,87 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
+import com.sitionix.bffssox.usecase.GetAgentChatExecution;
+import com.sitionix.bffssox.usecase.SubmitAgentChatExecution;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentChatControllerTest {
+
+    private AgentChatController agentChatController;
+
+    @Mock private ChatAgentApiMapper chatAgentApiMapper;
+    @Mock private SubmitAgentChatExecution submitAgentChatExecution;
+    @Mock private GetAgentChatExecution getAgentChatExecution;
+
+    @BeforeEach
+    void setUp() {
+        this.agentChatController = new AgentChatController(this.chatAgentApiMapper, this.submitAgentChatExecution, this.getAgentChatExecution);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.chatAgentApiMapper, this.submitAgentChatExecution, this.getAgentChatExecution);
+    }
+
+    @Test
+    void givenSubmitExecutionRequest_whenSubmitAgentChatExecution_thenReturnAcceptedEnvelope() {
+        //given
+        final UUID agentId = UUID.fromString("76f023a2-cb0c-44d5-970d-053f4af51f6b");
+        final ChatAgentRequestDTO requestDto = mock(ChatAgentRequestDTO.class);
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final SubmitChatExecutionResponse response = mock(SubmitChatExecutionResponse.class);
+        final SubmitChatExecutionResponseDTO responseDto = mock(SubmitChatExecutionResponseDTO.class);
+        when(this.chatAgentApiMapper.asChatAgentRequest(requestDto)).thenReturn(request);
+        when(this.submitAgentChatExecution.execute(agentId, request, "idem")).thenReturn(response);
+        when(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<SubmitChatExecutionResponseDTO> actual = this.agentChatController.submitAgentChatExecution(agentId, requestDto, "idem");
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.accepted().body(responseDto));
+        verify(this.chatAgentApiMapper).asChatAgentRequest(requestDto);
+        verify(this.submitAgentChatExecution).execute(agentId, request, "idem");
+        verify(this.chatAgentApiMapper).asSubmitChatExecutionResponseDto(response);
+    }
+
+    @Test
+    void givenExecutionLookupRequest_whenGetAgentChatExecution_thenReturnOkResponse() {
+        //given
+        final UUID agentId = UUID.fromString("1f723177-ec03-4506-9011-cf0b39c97c61");
+        final UUID executionId = UUID.fromString("d67d95cb-8fcb-4a09-8f17-4ad5295a784b");
+        final UUID conversationId = UUID.fromString("3b08ad4e-13f6-4d83-ab5d-dfe04ccebe4f");
+        final ChatExecution response = mock(ChatExecution.class);
+        final ChatExecutionDTO responseDto = mock(ChatExecutionDTO.class);
+        when(this.getAgentChatExecution.execute(agentId, executionId, conversationId)).thenReturn(response);
+        when(this.chatAgentApiMapper.asChatExecutionDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<ChatExecutionDTO> actual = this.agentChatController.getAgentChatExecution(agentId, executionId, conversationId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentChatExecution).execute(agentId, executionId, conversationId);
+        verify(this.chatAgentApiMapper).asChatExecutionDto(response);
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -1,9 +1,13 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
@@ -23,11 +27,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -78,5 +85,94 @@ class AgentControllerTest {
         verify(this.createAgentApiMapper).asCreateAgentRequest(requestDto);
         verify(this.createAgent).execute(request);
         verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenNoInput_whenGetAgents_thenReturnAgentsResponseDto() {
+        //given
+        final AgentsResponse response = mock(AgentsResponse.class);
+        final AgentsResponseDTO responseDto = mock(AgentsResponseDTO.class);
+        when(this.getAgents.execute()).thenReturn(response);
+        when(this.agentApiMapper.asAgentsResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentsResponseDTO> actual = this.agentController.getAgents();
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgents).execute();
+        verify(this.agentApiMapper).asAgentsResponseDto(response);
+    }
+
+    @Test
+    void givenAgentId_whenGetActivateArchiveRestoreDeleteAgent_thenReturnAgentDtos() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final Agent agent = mock(Agent.class);
+        final AgentDTO dto = mock(AgentDTO.class);
+        when(this.getAgent.execute(agentId)).thenReturn(agent);
+        when(this.activateAgent.execute(agentId)).thenReturn(agent);
+        when(this.archiveAgent.execute(agentId)).thenReturn(agent);
+        when(this.restoreAgent.execute(agentId)).thenReturn(agent);
+        when(this.deleteAgent.execute(agentId)).thenReturn(agent);
+        when(this.agentApiMapper.asAgentDto(agent)).thenReturn(dto);
+
+        //when
+        final ResponseEntity<AgentDTO> getResponse = this.agentController.getAgent(agentId);
+        final ResponseEntity<AgentDTO> activateResponse = this.agentController.activateAgent(agentId);
+        final ResponseEntity<AgentDTO> archiveResponse = this.agentController.archiveAgent(agentId);
+        final ResponseEntity<AgentDTO> restoreResponse = this.agentController.restoreAgent(agentId);
+        final ResponseEntity<AgentDTO> deleteResponse = this.agentController.deleteAgent(agentId);
+
+        //then
+        assertThat(getResponse).isEqualTo(ResponseEntity.ok(dto));
+        assertThat(activateResponse).isEqualTo(ResponseEntity.ok(dto));
+        assertThat(archiveResponse).isEqualTo(ResponseEntity.ok(dto));
+        assertThat(restoreResponse).isEqualTo(ResponseEntity.ok(dto));
+        assertThat(deleteResponse).isEqualTo(ResponseEntity.ok(dto));
+        verify(this.getAgent).execute(agentId);
+        verify(this.activateAgent).execute(agentId);
+        verify(this.archiveAgent).execute(agentId);
+        verify(this.restoreAgent).execute(agentId);
+        verify(this.deleteAgent).execute(agentId);
+        verify(this.agentApiMapper, times(5)).asAgentDto(agent);
+    }
+
+    @Test
+    void givenPatchPayloadWithValues_whenPatchAgent_thenReturnAgentDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final PatchAgentRequestDTO requestDto = mock(PatchAgentRequestDTO.class);
+        final PatchAgentRequest request = mock(PatchAgentRequest.class);
+        final Agent response = mock(Agent.class);
+        final AgentDTO responseDto = mock(AgentDTO.class);
+        when(requestDto.getName()).thenReturn("name");
+        when(this.patchAgentApiMapper.asPatchAgentRequest(requestDto)).thenReturn(request);
+        when(this.patchAgent.execute(agentId, request)).thenReturn(response);
+        when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentDTO> actual = this.agentController.patchAgent(agentId, requestDto);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.patchAgentApiMapper).asPatchAgentRequest(requestDto);
+        verify(this.patchAgent).execute(agentId, request);
+        verify(this.agentApiMapper).asAgentDto(response);
+    }
+
+    @Test
+    void givenEmptyPatchPayload_whenPatchAgent_thenThrowIllegalArgumentException() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final PatchAgentRequestDTO requestDto = mock(PatchAgentRequestDTO.class);
+        when(requestDto.getName()).thenReturn(null);
+        when(requestDto.getDescription()).thenReturn(null);
+        when(requestDto.getInstruction()).thenReturn(null);
+
+        //when/then
+        assertThatThrownBy(() -> this.agentController.patchAgent(agentId, requestDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Patch payload cannot be empty");
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentControllerTest.java
@@ -1,48 +1,20 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
-import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
-import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
-import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentRequestDTO;
-import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
-import com.sitionix.bffssox.domain.AgentProject;
-import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
-import com.sitionix.bffssox.domain.ChatAgentRequest;
-import com.sitionix.bffssox.domain.ChatExecution;
-import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
-import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
-import com.sitionix.bffssox.mapper.AgentRuleApiMapper;
-import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentApiMapper;
-import com.sitionix.bffssox.mapper.CreateAgentProjectApiMapper;
 import com.sitionix.bffssox.mapper.PatchAgentApiMapper;
 import com.sitionix.bffssox.usecase.ActivateAgent;
 import com.sitionix.bffssox.usecase.ArchiveAgent;
 import com.sitionix.bffssox.usecase.CreateAgent;
-import com.sitionix.bffssox.usecase.CreateAgentProject;
-import com.sitionix.bffssox.usecase.CreateAgentRule;
 import com.sitionix.bffssox.usecase.DeleteAgent;
-import com.sitionix.bffssox.usecase.DeleteAgentConversation;
-import com.sitionix.bffssox.usecase.DeleteAgentRule;
 import com.sitionix.bffssox.usecase.GetAgent;
-import com.sitionix.bffssox.usecase.GetAgentChatExecution;
-import com.sitionix.bffssox.usecase.GetAgentConversation;
-import com.sitionix.bffssox.usecase.GetAgentConversations;
-import com.sitionix.bffssox.usecase.GetAgentRules;
 import com.sitionix.bffssox.usecase.GetAgents;
-import com.sitionix.bffssox.usecase.GetAgentProjects;
-import com.sitionix.bffssox.usecase.GetAgentProject;
 import com.sitionix.bffssox.usecase.PatchAgent;
-import com.sitionix.bffssox.usecase.PatchAgentRule;
 import com.sitionix.bffssox.usecase.RestoreAgent;
-import com.sitionix.bffssox.usecase.SubmitAgentChatExecution;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,94 +36,27 @@ class AgentControllerTest {
     private AgentController agentController;
 
     @Mock private CreateAgentApiMapper createAgentApiMapper;
-    @Mock private CreateAgentProjectApiMapper createAgentProjectApiMapper;
     @Mock private AgentApiMapper agentApiMapper;
-    @Mock private AgentRuleApiMapper agentRuleApiMapper;
     @Mock private CreateAgent createAgent;
-    @Mock private CreateAgentProject createAgentProject;
     @Mock private PatchAgentApiMapper patchAgentApiMapper;
     @Mock private PatchAgent patchAgent;
-    @Mock private ChatAgentApiMapper chatAgentApiMapper;
-    @Mock private SubmitAgentChatExecution submitAgentChatExecution;
-    @Mock private GetAgentChatExecution getAgentChatExecution;
     @Mock private GetAgents getAgents;
-    @Mock private GetAgentProjects getAgentProjects;
-    @Mock private GetAgentProject getAgentProject;
     @Mock private GetAgent getAgent;
-    @Mock private GetAgentConversations getAgentConversations;
-    @Mock private GetAgentConversation getAgentConversation;
     @Mock private ActivateAgent activateAgent;
     @Mock private ArchiveAgent archiveAgent;
     @Mock private RestoreAgent restoreAgent;
     @Mock private DeleteAgent deleteAgent;
-    @Mock private GetAgentRules getAgentRules;
-    @Mock private CreateAgentRule createAgentRule;
-    @Mock private PatchAgentRule patchAgentRule;
-    @Mock private DeleteAgentRule deleteAgentRule;
-    @Mock private DeleteAgentConversation deleteAgentConversation;
 
     @BeforeEach
     void setUp() {
-        this.agentController = new AgentController(
-                this.createAgentApiMapper,
-                this.createAgentProjectApiMapper,
-                this.agentApiMapper,
-                this.agentRuleApiMapper,
-                this.createAgent,
-                this.createAgentProject,
-                this.patchAgentApiMapper,
-                this.patchAgent,
-                this.chatAgentApiMapper,
-                this.submitAgentChatExecution,
-                this.getAgentChatExecution,
-                this.getAgents,
-                this.getAgentProjects,
-                this.getAgentProject,
-                this.getAgent,
-                this.getAgentConversations,
-                this.getAgentConversation,
-                this.activateAgent,
-                this.archiveAgent,
-                this.restoreAgent,
-                this.deleteAgent,
-                this.getAgentRules,
-                this.createAgentRule,
-                this.patchAgentRule,
-                this.deleteAgentRule,
-                this.deleteAgentConversation
-        );
+        this.agentController = new AgentController(this.createAgentApiMapper, this.agentApiMapper, this.createAgent, this.patchAgentApiMapper,
+                this.patchAgent, this.getAgents, this.getAgent, this.activateAgent, this.archiveAgent, this.restoreAgent, this.deleteAgent);
     }
 
     @AfterEach
     void tearDown() {
-        verifyNoMoreInteractions(
-                this.createAgentApiMapper,
-                this.createAgentProjectApiMapper,
-                this.agentApiMapper,
-                this.agentRuleApiMapper,
-                this.createAgent,
-                this.createAgentProject,
-                this.patchAgentApiMapper,
-                this.patchAgent,
-                this.chatAgentApiMapper,
-                this.submitAgentChatExecution,
-                this.getAgentChatExecution,
-                this.getAgents,
-                this.getAgentProjects,
-                this.getAgentProject,
-                this.getAgent,
-                this.getAgentConversations,
-                this.getAgentConversation,
-                this.activateAgent,
-                this.archiveAgent,
-                this.restoreAgent,
-                this.deleteAgent,
-                this.getAgentRules,
-                this.createAgentRule,
-                this.patchAgentRule,
-                this.deleteAgentRule,
-                this.deleteAgentConversation
-        );
+        verifyNoMoreInteractions(this.createAgentApiMapper, this.agentApiMapper, this.createAgent, this.patchAgentApiMapper, this.patchAgent,
+                this.getAgents, this.getAgent, this.activateAgent, this.archiveAgent, this.restoreAgent, this.deleteAgent);
     }
 
     @Test
@@ -161,7 +66,6 @@ class AgentControllerTest {
         final CreateAgentRequest request = mock(CreateAgentRequest.class);
         final Agent response = mock(Agent.class);
         final AgentDTO responseDto = mock(AgentDTO.class);
-
         when(this.createAgentApiMapper.asCreateAgentRequest(requestDto)).thenReturn(request);
         when(this.createAgent.execute(request)).thenReturn(response);
         when(this.agentApiMapper.asAgentDto(response)).thenReturn(responseDto);
@@ -174,145 +78,5 @@ class AgentControllerTest {
         verify(this.createAgentApiMapper).asCreateAgentRequest(requestDto);
         verify(this.createAgent).execute(request);
         verify(this.agentApiMapper).asAgentDto(response);
-    }
-
-    @Test
-    void givenSubmitExecutionRequest_whenSubmitAgentChatExecution_thenReturnAcceptedEnvelope() {
-        //given
-        final UUID agentId = UUID.fromString("76f023a2-cb0c-44d5-970d-053f4af51f6b");
-        final ChatAgentRequestDTO requestDto = mock(ChatAgentRequestDTO.class);
-        final ChatAgentRequest request = mock(ChatAgentRequest.class);
-        final SubmitChatExecutionResponse response = mock(SubmitChatExecutionResponse.class);
-        final SubmitChatExecutionResponseDTO responseDto = mock(SubmitChatExecutionResponseDTO.class);
-
-        when(this.chatAgentApiMapper.asChatAgentRequest(requestDto)).thenReturn(request);
-        when(this.submitAgentChatExecution.execute(agentId, request, "idem")).thenReturn(response);
-        when(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response)).thenReturn(responseDto);
-
-        //when
-        final ResponseEntity<SubmitChatExecutionResponseDTO> actual =
-                this.agentController.submitAgentChatExecution(agentId, requestDto, "idem");
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.accepted().body(responseDto));
-        verify(this.chatAgentApiMapper).asChatAgentRequest(requestDto);
-        verify(this.submitAgentChatExecution).execute(agentId, request, "idem");
-        verify(this.chatAgentApiMapper).asSubmitChatExecutionResponseDto(response);
-    }
-
-    @Test
-    void givenSubmitExecutionRequest_whenSubmitAgentChatExecutionByExecutionsPath_thenDelegateToSubmitFlow() {
-        //given
-        final UUID agentId = UUID.fromString("f318a8d4-c8d5-44f2-ad4b-b3a6a900e955");
-        final ChatAgentRequestDTO requestDto = mock(ChatAgentRequestDTO.class);
-        final ChatAgentRequest request = mock(ChatAgentRequest.class);
-        final SubmitChatExecutionResponse response = mock(SubmitChatExecutionResponse.class);
-        final SubmitChatExecutionResponseDTO responseDto = mock(SubmitChatExecutionResponseDTO.class);
-
-        when(this.chatAgentApiMapper.asChatAgentRequest(requestDto)).thenReturn(request);
-        when(this.submitAgentChatExecution.execute(agentId, request, "idem")).thenReturn(response);
-        when(this.chatAgentApiMapper.asSubmitChatExecutionResponseDto(response)).thenReturn(responseDto);
-
-        //when
-        final ResponseEntity<SubmitChatExecutionResponseDTO> actual =
-                this.agentController.submitAgentChatExecutionByExecutionsPath(agentId, requestDto, "idem");
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.accepted().body(responseDto));
-        verify(this.chatAgentApiMapper).asChatAgentRequest(requestDto);
-        verify(this.submitAgentChatExecution).execute(agentId, request, "idem");
-        verify(this.chatAgentApiMapper).asSubmitChatExecutionResponseDto(response);
-    }
-
-    @Test
-    void givenExecutionLookupRequest_whenGetAgentChatExecution_thenReturnOkResponse() {
-        //given
-        final UUID agentId = UUID.fromString("1f723177-ec03-4506-9011-cf0b39c97c61");
-        final UUID executionId = UUID.fromString("d67d95cb-8fcb-4a09-8f17-4ad5295a784b");
-        final UUID conversationId = UUID.fromString("3b08ad4e-13f6-4d83-ab5d-dfe04ccebe4f");
-        final ChatExecution response = mock(ChatExecution.class);
-        final ChatExecutionDTO responseDto = mock(ChatExecutionDTO.class);
-
-        when(this.getAgentChatExecution.execute(agentId, executionId, conversationId)).thenReturn(response);
-        when(this.chatAgentApiMapper.asChatExecutionDto(response)).thenReturn(responseDto);
-
-        //when
-        final ResponseEntity<ChatExecutionDTO> actual =
-                this.agentController.getAgentChatExecution(agentId, executionId, conversationId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
-        verify(this.getAgentChatExecution).execute(agentId, executionId, conversationId);
-        verify(this.chatAgentApiMapper).asChatExecutionDto(response);
-    }
-
-    @Test
-    void givenConversationId_whenDeleteAgentConversation_thenReturnNoContent() {
-        //given
-        final UUID conversationId = UUID.fromString("4dd6a86d-7de1-4187-9624-fc912633b102");
-
-        //when
-        final ResponseEntity<Void> actual = this.agentController.deleteAgentConversation(conversationId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.noContent().build());
-        verify(this.deleteAgentConversation).execute(conversationId);
-    }
-
-    @Test
-    void givenCreateAgentProjectRequestDto_whenCreateAgentProject_thenReturnCreatedResponse() {
-        //given
-        final CreateAgentProjectRequestDTO requestDto = mock(CreateAgentProjectRequestDTO.class);
-        final CreateAgentProjectRequest request = mock(CreateAgentProjectRequest.class);
-        final AgentProject response = mock(AgentProject.class);
-        final AgentProjectDTO responseDto = mock(AgentProjectDTO.class);
-
-        when(this.createAgentProjectApiMapper.asCreateAgentProjectRequest(requestDto)).thenReturn(request);
-        when(this.createAgentProject.execute(request)).thenReturn(response);
-        when(this.agentApiMapper.asAgentProjectDto(response)).thenReturn(responseDto);
-
-        //when
-        final ResponseEntity<AgentProjectDTO> actual = this.agentController.createAgentProject(requestDto);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(responseDto));
-        verify(this.createAgentProjectApiMapper).asCreateAgentProjectRequest(requestDto);
-        verify(this.createAgentProject).execute(request);
-        verify(this.agentApiMapper).asAgentProjectDto(response);
-    }
-
-    @Test
-    void givenPageAndSize_whenGetAgentProjects_thenReturnOkProjectsPageResponse() {
-        //given
-        final AgentProjectsPageResponse response = mock(AgentProjectsPageResponse.class);
-        final AgentProjectsPageResponseDTO responseDto = mock(AgentProjectsPageResponseDTO.class);
-        when(this.getAgentProjects.execute(1, 30)).thenReturn(response);
-        when(this.agentApiMapper.asAgentProjectsPageResponseDto(response)).thenReturn(responseDto);
-
-        //when
-        final ResponseEntity<AgentProjectsPageResponseDTO> actual = this.agentController.getAgentProjects(1, 30);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
-        verify(this.getAgentProjects).execute(1, 30);
-        verify(this.agentApiMapper).asAgentProjectsPageResponseDto(response);
-    }
-
-    @Test
-    void givenProjectId_whenGetAgentProject_thenReturnOkProjectResponse() {
-        //given
-        final UUID projectId = UUID.fromString("09e25bcf-f8a2-4f6c-860c-bf1af25dbbba");
-        final AgentProject response = mock(AgentProject.class);
-        final AgentProjectDTO responseDto = mock(AgentProjectDTO.class);
-        when(this.getAgentProject.execute(projectId)).thenReturn(response);
-        when(this.agentApiMapper.asAgentProjectDto(response)).thenReturn(responseDto);
-
-        //when
-        final ResponseEntity<AgentProjectDTO> actual = this.agentController.getAgentProject(projectId);
-
-        //then
-        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
-        verify(this.getAgentProject).execute(projectId);
-        verify(this.agentApiMapper).asAgentProjectDto(response);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentConversationControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentConversationControllerTest.java
@@ -1,5 +1,9 @@
 package com.sitionix.bffssox.controller;
 
+import com.app_afesox.bffssox.api_first.dto.AgentConversationDetailsDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
+import com.sitionix.bffssox.domain.AgentConversationDetails;
+import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
 import com.sitionix.bffssox.usecase.DeleteAgentConversation;
 import com.sitionix.bffssox.usecase.GetAgentConversation;
@@ -14,8 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AgentConversationControllerTest {
@@ -49,5 +55,41 @@ class AgentConversationControllerTest {
         //then
         assertThat(actual).isEqualTo(ResponseEntity.noContent().build());
         verify(this.deleteAgentConversation).execute(conversationId);
+    }
+
+    @Test
+    void givenAgentId_whenGetAgentConversations_thenReturnMappedResponse() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final AgentConversationsResponse response = mock(AgentConversationsResponse.class);
+        final AgentConversationsResponseDTO responseDto = mock(AgentConversationsResponseDTO.class);
+        when(this.getAgentConversations.execute(agentId)).thenReturn(response);
+        when(this.chatAgentApiMapper.asAgentConversationsResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentConversationsResponseDTO> actual = this.agentConversationController.getAgentConversations(agentId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentConversations).execute(agentId);
+        verify(this.chatAgentApiMapper).asAgentConversationsResponseDto(response);
+    }
+
+    @Test
+    void givenConversationId_whenGetAgentConversation_thenReturnMappedResponse() {
+        //given
+        final UUID conversationId = UUID.randomUUID();
+        final AgentConversationDetails response = mock(AgentConversationDetails.class);
+        final AgentConversationDetailsDTO responseDto = mock(AgentConversationDetailsDTO.class);
+        when(this.getAgentConversation.execute(conversationId)).thenReturn(response);
+        when(this.chatAgentApiMapper.asAgentConversationDetailsDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentConversationDetailsDTO> actual = this.agentConversationController.getAgentConversation(conversationId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentConversation).execute(conversationId);
+        verify(this.chatAgentApiMapper).asAgentConversationDetailsDto(response);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentConversationControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentConversationControllerTest.java
@@ -1,0 +1,53 @@
+package com.sitionix.bffssox.controller;
+
+import com.sitionix.bffssox.mapper.ChatAgentApiMapper;
+import com.sitionix.bffssox.usecase.DeleteAgentConversation;
+import com.sitionix.bffssox.usecase.GetAgentConversation;
+import com.sitionix.bffssox.usecase.GetAgentConversations;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class AgentConversationControllerTest {
+
+    private AgentConversationController agentConversationController;
+
+    @Mock private ChatAgentApiMapper chatAgentApiMapper;
+    @Mock private GetAgentConversations getAgentConversations;
+    @Mock private GetAgentConversation getAgentConversation;
+    @Mock private DeleteAgentConversation deleteAgentConversation;
+
+    @BeforeEach
+    void setUp() {
+        this.agentConversationController = new AgentConversationController(this.chatAgentApiMapper, this.getAgentConversations,
+                this.getAgentConversation, this.deleteAgentConversation);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.chatAgentApiMapper, this.getAgentConversations, this.getAgentConversation, this.deleteAgentConversation);
+    }
+
+    @Test
+    void givenConversationId_whenDeleteAgentConversation_thenReturnNoContent() {
+        //given
+        final UUID conversationId = UUID.fromString("4dd6a86d-7de1-4187-9624-fc912633b102");
+
+        //when
+        final ResponseEntity<Void> actual = this.agentConversationController.deleteAgentConversation(conversationId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.noContent().build());
+        verify(this.deleteAgentConversation).execute(conversationId);
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentProjectControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentProjectControllerTest.java
@@ -1,8 +1,10 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
 import com.sitionix.bffssox.mapper.AgentApiMapper;
 import com.sitionix.bffssox.mapper.CreateAgentProjectApiMapper;
@@ -64,6 +66,41 @@ class AgentProjectControllerTest {
         assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(responseDto));
         verify(this.createAgentProjectApiMapper).asCreateAgentProjectRequest(requestDto);
         verify(this.createAgentProject).execute(request);
+        verify(this.agentApiMapper).asAgentProjectDto(response);
+    }
+
+    @Test
+    void givenPageAndSize_whenGetAgentProjects_thenReturnProjectsPageResponseDto() {
+        //given
+        final AgentProjectsPageResponse response = mock(AgentProjectsPageResponse.class);
+        final AgentProjectsPageResponseDTO responseDto = mock(AgentProjectsPageResponseDTO.class);
+        when(this.getAgentProjects.execute(1, 20)).thenReturn(response);
+        when(this.agentApiMapper.asAgentProjectsPageResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentProjectsPageResponseDTO> actual = this.agentProjectController.getAgentProjects(1, 20);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentProjects).execute(1, 20);
+        verify(this.agentApiMapper).asAgentProjectsPageResponseDto(response);
+    }
+
+    @Test
+    void givenProjectId_whenGetAgentProject_thenReturnProjectDto() {
+        //given
+        final java.util.UUID projectId = java.util.UUID.randomUUID();
+        final AgentProject response = mock(AgentProject.class);
+        final AgentProjectDTO responseDto = mock(AgentProjectDTO.class);
+        when(this.getAgentProject.execute(projectId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentProjectDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentProjectDTO> actual = this.agentProjectController.getAgentProject(projectId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentProject).execute(projectId);
         verify(this.agentApiMapper).asAgentProjectDto(response);
     }
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentProjectControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentProjectControllerTest.java
@@ -1,0 +1,69 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
+import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
+import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
+import com.sitionix.bffssox.mapper.AgentApiMapper;
+import com.sitionix.bffssox.mapper.CreateAgentProjectApiMapper;
+import com.sitionix.bffssox.usecase.CreateAgentProject;
+import com.sitionix.bffssox.usecase.GetAgentProject;
+import com.sitionix.bffssox.usecase.GetAgentProjects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentProjectControllerTest {
+
+    private AgentProjectController agentProjectController;
+
+    @Mock private CreateAgentProjectApiMapper createAgentProjectApiMapper;
+    @Mock private AgentApiMapper agentApiMapper;
+    @Mock private CreateAgentProject createAgentProject;
+    @Mock private GetAgentProjects getAgentProjects;
+    @Mock private GetAgentProject getAgentProject;
+
+    @BeforeEach
+    void setUp() {
+        this.agentProjectController = new AgentProjectController(this.createAgentProjectApiMapper, this.agentApiMapper,
+                this.createAgentProject, this.getAgentProjects, this.getAgentProject);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.createAgentProjectApiMapper, this.agentApiMapper, this.createAgentProject, this.getAgentProjects, this.getAgentProject);
+    }
+
+    @Test
+    void givenCreateAgentProjectRequestDto_whenCreateAgentProject_thenReturnCreatedResponse() {
+        //given
+        final CreateAgentProjectRequestDTO requestDto = mock(CreateAgentProjectRequestDTO.class);
+        final CreateAgentProjectRequest request = mock(CreateAgentProjectRequest.class);
+        final AgentProject response = mock(AgentProject.class);
+        final AgentProjectDTO responseDto = mock(AgentProjectDTO.class);
+        when(this.createAgentProjectApiMapper.asCreateAgentProjectRequest(requestDto)).thenReturn(request);
+        when(this.createAgentProject.execute(request)).thenReturn(response);
+        when(this.agentApiMapper.asAgentProjectDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentProjectDTO> actual = this.agentProjectController.createAgentProject(requestDto);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(responseDto));
+        verify(this.createAgentProjectApiMapper).asCreateAgentProjectRequest(requestDto);
+        verify(this.createAgentProject).execute(request);
+        verify(this.agentApiMapper).asAgentProjectDto(response);
+    }
+}

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentRuleControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentRuleControllerTest.java
@@ -1,0 +1,192 @@
+package com.sitionix.bffssox.controller;
+
+import com.app_afesox.bffssox.api_first.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRuleStatusDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentRulesResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.CreateAgentRuleRequestDTO;
+import com.app_afesox.bffssox.api_first.dto.DeleteAgentRuleResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
+import com.sitionix.bffssox.domain.AgentRule;
+import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
+import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
+import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
+import com.sitionix.bffssox.mapper.AgentRuleApiMapper;
+import com.sitionix.bffssox.usecase.AcceptAgentRule;
+import com.sitionix.bffssox.usecase.CreateAgentRule;
+import com.sitionix.bffssox.usecase.DeleteAgentRule;
+import com.sitionix.bffssox.usecase.GetAgentRules;
+import com.sitionix.bffssox.usecase.PatchAgentRule;
+import com.sitionix.bffssox.usecase.RejectAgentRule;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentRuleControllerTest {
+
+    private AgentRuleController agentRuleController;
+
+    @Mock private AgentRuleApiMapper agentRuleApiMapper;
+    @Mock private GetAgentRules getAgentRules;
+    @Mock private CreateAgentRule createAgentRule;
+    @Mock private PatchAgentRule patchAgentRule;
+    @Mock private DeleteAgentRule deleteAgentRule;
+    @Mock private AcceptAgentRule acceptAgentRule;
+    @Mock private RejectAgentRule rejectAgentRule;
+
+    @BeforeEach
+    void setUp() {
+        this.agentRuleController = new AgentRuleController(this.agentRuleApiMapper, this.getAgentRules, this.createAgentRule,
+                this.patchAgentRule, this.deleteAgentRule, this.acceptAgentRule, this.rejectAgentRule);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentRuleApiMapper, this.getAgentRules, this.createAgentRule, this.patchAgentRule,
+                this.deleteAgentRule, this.acceptAgentRule, this.rejectAgentRule);
+    }
+
+    @Test
+    void givenAgentIdAndFilters_whenGetAgentRules_thenReturnRulesResponseDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final AgentRuleStatusDTO status = mock(AgentRuleStatusDTO.class);
+        final GetAgentRulesQuery query = mock(GetAgentRulesQuery.class);
+        final AgentRulesResponse rules = mock(AgentRulesResponse.class);
+        final AgentRulesResponseDTO response = mock(AgentRulesResponseDTO.class);
+        when(this.agentRuleApiMapper.asGetAgentRulesQuery(status, null)).thenReturn(query);
+        when(this.getAgentRules.execute(agentId, query)).thenReturn(rules);
+        when(this.agentRuleApiMapper.asAgentRulesResponseDto(rules)).thenReturn(response);
+
+        //when
+        final ResponseEntity<AgentRulesResponseDTO> actual = this.agentRuleController.getAgentRules(agentId, status, null);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(response));
+        verify(this.agentRuleApiMapper).asGetAgentRulesQuery(status, null);
+        verify(this.getAgentRules).execute(agentId, query);
+        verify(this.agentRuleApiMapper).asAgentRulesResponseDto(rules);
+    }
+
+    @Test
+    void givenCreateRequest_whenCreateAgentRule_thenReturnCreatedRuleDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final CreateAgentRuleRequestDTO requestDto = mock(CreateAgentRuleRequestDTO.class);
+        final CreateAgentRuleRequest request = mock(CreateAgentRuleRequest.class);
+        final AgentRule rule = mock(AgentRule.class);
+        final AgentRuleDTO response = mock(AgentRuleDTO.class);
+        when(this.agentRuleApiMapper.asCreateAgentRuleRequest(requestDto)).thenReturn(request);
+        when(this.createAgentRule.execute(agentId, request)).thenReturn(rule);
+        when(this.agentRuleApiMapper.asAgentRuleDto(rule)).thenReturn(response);
+
+        //when
+        final ResponseEntity<AgentRuleDTO> actual = this.agentRuleController.createAgentRule(agentId, requestDto);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.status(HttpStatus.CREATED).body(response));
+        verify(this.agentRuleApiMapper).asCreateAgentRuleRequest(requestDto);
+        verify(this.createAgentRule).execute(agentId, request);
+        verify(this.agentRuleApiMapper).asAgentRuleDto(rule);
+    }
+
+    @Test
+    void givenPatchRequest_whenPatchAgentRule_thenReturnPatchedRuleDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final PatchAgentRuleRequestDTO requestDto = mock(PatchAgentRuleRequestDTO.class);
+        final PatchAgentRuleRequest request = mock(PatchAgentRuleRequest.class);
+        final AgentRule rule = mock(AgentRule.class);
+        final AgentRuleDTO response = mock(AgentRuleDTO.class);
+        when(this.agentRuleApiMapper.asPatchAgentRuleRequest(requestDto)).thenReturn(request);
+        when(this.patchAgentRule.execute(agentId, ruleId, request)).thenReturn(rule);
+        when(this.agentRuleApiMapper.asAgentRuleDto(rule)).thenReturn(response);
+
+        //when
+        final ResponseEntity<AgentRuleDTO> actual = this.agentRuleController.patchAgentRule(agentId, ruleId, requestDto);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(response));
+        verify(this.agentRuleApiMapper).asPatchAgentRuleRequest(requestDto);
+        verify(this.patchAgentRule).execute(agentId, ruleId, request);
+        verify(this.agentRuleApiMapper).asAgentRuleDto(rule);
+    }
+
+    @Test
+    void givenRuleId_whenDeleteAgentRule_thenReturnDeleteResponseDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final DeleteAgentRuleResponse deleteResponse = mock(DeleteAgentRuleResponse.class);
+        final DeleteAgentRuleResponseDTO response = mock(DeleteAgentRuleResponseDTO.class);
+        when(this.deleteAgentRule.execute(agentId, ruleId)).thenReturn(deleteResponse);
+        when(this.agentRuleApiMapper.asDeleteAgentRuleResponseDto(deleteResponse)).thenReturn(response);
+
+        //when
+        final ResponseEntity<DeleteAgentRuleResponseDTO> actual = this.agentRuleController.deleteAgentRule(agentId, ruleId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(response));
+        verify(this.deleteAgentRule).execute(agentId, ruleId);
+        verify(this.agentRuleApiMapper).asDeleteAgentRuleResponseDto(deleteResponse);
+    }
+
+    @Test
+    void givenAcceptRequest_whenAcceptAgentRule_thenReturnAcceptedRuleDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final AcceptAgentRuleRequestDTO requestDto = mock(AcceptAgentRuleRequestDTO.class);
+        final AcceptAgentRuleRequest request = mock(AcceptAgentRuleRequest.class);
+        final AgentRule rule = mock(AgentRule.class);
+        final AgentRuleDTO response = mock(AgentRuleDTO.class);
+        when(this.agentRuleApiMapper.asAcceptAgentRuleRequest(requestDto)).thenReturn(request);
+        when(this.acceptAgentRule.execute(agentId, ruleId, request)).thenReturn(rule);
+        when(this.agentRuleApiMapper.asAgentRuleDto(rule)).thenReturn(response);
+
+        //when
+        final ResponseEntity<AgentRuleDTO> actual = this.agentRuleController.acceptAgentRule(agentId, ruleId, requestDto);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(response));
+        verify(this.agentRuleApiMapper).asAcceptAgentRuleRequest(requestDto);
+        verify(this.acceptAgentRule).execute(agentId, ruleId, request);
+        verify(this.agentRuleApiMapper).asAgentRuleDto(rule);
+    }
+
+    @Test
+    void givenAgentAndRuleId_whenRejectAgentRule_thenReturnRejectedRuleDto() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final AgentRule rule = mock(AgentRule.class);
+        final AgentRuleDTO response = mock(AgentRuleDTO.class);
+        when(this.rejectAgentRule.execute(agentId, ruleId)).thenReturn(rule);
+        when(this.agentRuleApiMapper.asAgentRuleDto(rule)).thenReturn(response);
+
+        //when
+        final ResponseEntity<AgentRuleDTO> actual = this.agentRuleController.rejectAgentRule(agentId, ruleId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(response));
+        verify(this.rejectAgentRule).execute(agentId, ruleId);
+        verify(this.agentRuleApiMapper).asAgentRuleDto(rule);
+    }
+}

--- a/boot/src/main/java/com/sitionix/bffssox/config/AtmssoxApiConfig.java
+++ b/boot/src/main/java/com/sitionix/bffssox/config/AtmssoxApiConfig.java
@@ -1,6 +1,10 @@
 package com.sitionix.bffssox.config;
 
 import com.app_afesox.atmssox.client.api.AgentApi;
+import com.app_afesox.atmssox.client.api.AgentChatApi;
+import com.app_afesox.atmssox.client.api.AgentConversationApi;
+import com.app_afesox.atmssox.client.api.AgentProjectApi;
+import com.app_afesox.atmssox.client.api.AgentRuleApi;
 import com.app_afesox.atmssox.client.invoker.ApiClient;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +45,25 @@ public class AtmssoxApiConfig {
     @Bean
     public AgentApi agentApi(@Qualifier("atmssoxClient") final ApiClient apiClient) {
         return new AgentApi(apiClient);
+    }
+
+    @Bean
+    public AgentProjectApi agentProjectApi(@Qualifier("atmssoxClient") final ApiClient apiClient) {
+        return new AgentProjectApi(apiClient);
+    }
+
+    @Bean
+    public AgentConversationApi agentConversationApi(@Qualifier("atmssoxClient") final ApiClient apiClient) {
+        return new AgentConversationApi(apiClient);
+    }
+
+    @Bean
+    public AgentRuleApi agentRuleApi(@Qualifier("atmssoxClient") final ApiClient apiClient) {
+        return new AgentRuleApi(apiClient);
+    }
+
+    @Bean
+    public AgentChatApi agentChatApi(@Qualifier("atmssoxClient") final ApiClient apiClient) {
+        return new AgentChatApi(apiClient);
     }
 }

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.21</atmssox.api.version>
+        <atmssox.api.version>0.0.22</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-131-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-sitionix-131-unstable</artifactId>
+            <artifactId>app-afesox-atmssox-client-stable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentAtmssoxClient.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentAtmssoxClient.java
@@ -1,0 +1,70 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentApi;
+import com.app_afesox.atmssox.client.dto.AgentDTO;
+import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
+import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.domain.PatchAgentRequest;
+import com.sitionix.bffssox.mapper.AgentClientMapper;
+import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
+import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AgentAtmssoxClient {
+
+    private final AgentApi agentApi;
+    private final CreateAgentClientMapper createAgentClientMapper;
+    private final PatchAgentClientMapper patchAgentClientMapper;
+    private final AgentClientMapper agentClientMapper;
+    private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    public Agent createAgent(final CreateAgentRequest request) {
+        final CreateAgentRequestDTO requestDTO = this.createAgentClientMapper.asCreateAgentRequestDto(request);
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.createAgent(requestDTO));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    public AgentsResponse getAgents() {
+        final AgentsResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(this.agentApi::getAgents);
+        return this.agentClientMapper.asAgentsResponse(responseDTO);
+    }
+
+    public Agent getAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.getAgent(agentId));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    public Agent activateAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.activateAgent(agentId));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    public Agent archiveAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.archiveAgent(agentId));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    public Agent restoreAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.restoreAgent(agentId));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    public Agent deleteAgent(final UUID agentId) {
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.deleteAgent(agentId));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+
+    public Agent patchAgent(final UUID agentId, final PatchAgentRequest request) {
+        final PatchAgentRequestDTO requestDTO = this.patchAgentClientMapper.asPatchAgentRequestDto(request);
+        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentApi.patchAgent(agentId, requestDTO));
+        return this.agentClientMapper.asAgent(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentChatAtmssoxClient.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentChatAtmssoxClient.java
@@ -1,0 +1,39 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentChatApi;
+import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
+import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.SubmitChatExecutionResponseDTO;
+import com.sitionix.bffssox.domain.ChatExecution;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AgentChatAtmssoxClient {
+
+    private final AgentChatApi agentChatApi;
+    private final ChatAgentClientMapper chatAgentClientMapper;
+    private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    public SubmitChatExecutionResponse submitAgentChatExecution(final UUID agentId,
+                                                                final ChatAgentRequest request,
+                                                                final String idempotencyKey) {
+        final ChatAgentRequestDTO requestDTO = this.chatAgentClientMapper.asChatAgentRequestDto(request);
+        final SubmitChatExecutionResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentChatApi.submitAgentChatExecutionByExecutionsPath(agentId, requestDTO, idempotencyKey)
+        );
+        return this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO);
+    }
+
+    public ChatExecution getAgentChatExecution(final UUID agentId, final UUID executionId, final UUID conversationId) {
+        final ChatExecutionDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentChatApi.getAgentChatExecution(agentId, executionId, conversationId)
+        );
+        return this.chatAgentClientMapper.asChatExecution(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -1,36 +1,11 @@
 package com.sitionix.bffssox.client;
 
-import com.app_afesox.atmssox.client.api.AgentApi;
-import com.app_afesox.atmssox.client.api.AgentChatApi;
-import com.app_afesox.atmssox.client.api.AgentConversationApi;
-import com.app_afesox.atmssox.client.api.AgentProjectApi;
-import com.app_afesox.atmssox.client.api.AgentRuleApi;
-import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
-import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.SubmitChatExecutionResponseDTO;
-import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
-import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
-import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
-import com.app_afesox.atmssox.client.dto.AgentProjectsPageResponseDTO;
-import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
-import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
-import com.app_afesox.atmssox.client.dto.AgentDTO;
-import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
-import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
-import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
-import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
-import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
-import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.CreateAgentProjectRequestDTO;
-import com.app_afesox.atmssox.client.dto.DeleteAgentRuleResponseDTO;
-import com.app_afesox.atmssox.client.dto.PatchAgentRuleRequestDTO;
-import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.domain.AgentProject;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
-import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
 import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
@@ -44,226 +19,129 @@ import com.sitionix.bffssox.domain.GetAgentRulesQuery;
 import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.PatchAgentRequest;
 import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
-import com.sitionix.bffssox.mapper.AgentClientMapper;
-import com.sitionix.bffssox.mapper.AgentRuleClientMapper;
-import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
-import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
-import com.sitionix.bffssox.mapper.CreateAgentProjectClientMapper;
-import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient {
+public class AgentClientImpl implements AgentClient {
 
-    private final AgentApi agentApi;
-    private final AgentProjectApi agentProjectApi;
-    private final AgentConversationApi agentConversationApi;
-    private final AgentRuleApi agentRuleApi;
-    private final AgentChatApi agentChatApi;
-
-    private final CreateAgentClientMapper createAgentClientMapper;
-    private final CreateAgentProjectClientMapper createAgentProjectClientMapper;
-
-    private final AgentClientMapper agentClientMapper;
-
-    private final AgentRuleClientMapper agentRuleClientMapper;
-
-    private final PatchAgentClientMapper patchAgentClientMapper;
-
-    private final ChatAgentClientMapper chatAgentClientMapper;
-
-    private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+    private final AgentAtmssoxClient agentAtmssoxClient;
+    private final AgentProjectAtmssoxClient agentProjectAtmssoxClient;
+    private final AgentConversationAtmssoxClient agentConversationAtmssoxClient;
+    private final AgentRuleAtmssoxClient agentRuleAtmssoxClient;
+    private final AgentChatAtmssoxClient agentChatAtmssoxClient;
 
     @Override
     public Agent createAgent(final CreateAgentRequest request) {
-        final CreateAgentRequestDTO requestDTO = this.createAgentClientMapper.asCreateAgentRequestDto(request);
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.createAgent(requestDTO)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.createAgent(request);
     }
 
     @Override
     public AgentProject createAgentProject(final CreateAgentProjectRequest request) {
-        final CreateAgentProjectRequestDTO requestDTO = this.createAgentProjectClientMapper.asCreateAgentProjectRequestDto(request);
-        final AgentProjectDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentProjectApi.createAgentProject(requestDTO)
-        );
-        return this.agentClientMapper.asAgentProject(responseDTO);
+        return this.agentProjectAtmssoxClient.createAgentProject(request);
     }
 
     @Override
     public AgentsResponse getAgents() {
-        final AgentsResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(this.agentApi::getAgents);
-        return this.agentClientMapper.asAgentsResponse(responseDTO);
+        return this.agentAtmssoxClient.getAgents();
     }
 
     @Override
     public AgentProjectsPageResponse getAgentProjects(final Integer page, final Integer size) {
-        final AgentProjectsPageResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentProjectApi.getAgentProjects(page, size)
-        );
-        return this.agentClientMapper.asAgentProjectsPageResponse(responseDTO);
+        return this.agentProjectAtmssoxClient.getAgentProjects(page, size);
     }
 
     @Override
     public AgentProject getAgentProject(final UUID projectId) {
-        final AgentProjectDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentProjectApi.getAgentProject(projectId)
-        );
-        return this.agentClientMapper.asAgentProject(responseDTO);
+        return this.agentProjectAtmssoxClient.getAgentProject(projectId);
     }
 
     @Override
     public Agent getAgent(final UUID agentId) {
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgent(agentId)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.getAgent(agentId);
     }
 
     @Override
     public AgentConversationsResponse getAgentConversations(final UUID agentId) {
-        final AgentConversationsResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentConversationApi.getAgentConversations(agentId)
-        );
-        return this.chatAgentClientMapper.asAgentConversationsResponse(responseDTO);
+        return this.agentConversationAtmssoxClient.getAgentConversations(agentId);
     }
 
     @Override
     public AgentConversationDetails getAgentConversation(final UUID conversationId) {
-        final AgentConversationDetailsDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentConversationApi.getAgentConversation(conversationId)
-        );
-        return this.chatAgentClientMapper.asAgentConversationDetails(responseDTO);
+        return this.agentConversationAtmssoxClient.getAgentConversation(conversationId);
     }
 
     @Override
     public void deleteAgentConversation(final UUID conversationId) {
-        this.atmssoxClientCallExecutor.execute(
-                () -> {
-                    this.agentConversationApi.deleteAgentConversation(conversationId);
-                    return null;
-                }
-        );
+        this.agentConversationAtmssoxClient.deleteAgentConversation(conversationId);
     }
 
     @Override
     public Agent activateAgent(final UUID agentId) {
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.activateAgent(agentId)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.activateAgent(agentId);
     }
 
     @Override
     public Agent archiveAgent(final UUID agentId) {
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.archiveAgent(agentId)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.archiveAgent(agentId);
     }
 
     @Override
     public Agent restoreAgent(final UUID agentId) {
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.restoreAgent(agentId)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.restoreAgent(agentId);
     }
 
     @Override
     public Agent deleteAgent(final UUID agentId) {
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.deleteAgent(agentId)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.deleteAgent(agentId);
     }
 
     @Override
     public AgentRulesResponse getAgentRules(final UUID agentId, final GetAgentRulesQuery query) {
-        final AgentRuleStatusDTO status = query == null || query.status() == null ? null : AgentRuleStatusDTO.fromValue(query.status());
-        final AgentRuleAuthorTypeDTO authorType = query == null || query.authorType() == null
-                ? null
-                : AgentRuleAuthorTypeDTO.fromValue(query.authorType());
-        final AgentRulesResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentRuleApi.getAgentRules(agentId, status, authorType)
-        );
-        return this.agentRuleClientMapper.asAgentRulesResponse(responseDTO);
+        return this.agentRuleAtmssoxClient.getAgentRules(agentId, query);
     }
 
     @Override
     public AgentRule createAgentRule(final UUID agentId, final CreateAgentRuleRequest request) {
-        final CreateAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asCreateAgentRuleRequestDto(request);
-        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentRuleApi.createAgentRule(agentId, requestDTO)
-        );
-        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+        return this.agentRuleAtmssoxClient.createAgentRule(agentId, request);
     }
 
     @Override
     public AgentRule patchAgentRule(final UUID agentId, final UUID ruleId, final PatchAgentRuleRequest request) {
-        final PatchAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asPatchAgentRuleRequestDto(request);
-        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentRuleApi.patchAgentRule(agentId, ruleId, requestDTO)
-        );
-        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+        return this.agentRuleAtmssoxClient.patchAgentRule(agentId, ruleId, request);
     }
 
     @Override
     public AgentRule acceptAgentRule(final UUID agentId, final UUID ruleId, final AcceptAgentRuleRequest request) {
-        final AcceptAgentRuleRequestDTO requestDTO = request == null ? null : this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request);
-        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentRuleApi.acceptAgentRule(agentId, ruleId, requestDTO)
-        );
-        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+        return this.agentRuleAtmssoxClient.acceptAgentRule(agentId, ruleId, request);
     }
 
     @Override
     public AgentRule rejectAgentRule(final UUID agentId, final UUID ruleId) {
-        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentRuleApi.rejectAgentRule(agentId, ruleId)
-        );
-        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+        return this.agentRuleAtmssoxClient.rejectAgentRule(agentId, ruleId);
     }
 
     @Override
     public DeleteAgentRuleResponse deleteAgentRule(final UUID agentId, final UUID ruleId) {
-        final DeleteAgentRuleResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentRuleApi.deleteAgentRule(agentId, ruleId)
-        );
-        return this.agentRuleClientMapper.asDeleteAgentRuleResponse(responseDTO);
+        return this.agentRuleAtmssoxClient.deleteAgentRule(agentId, ruleId);
     }
 
     @Override
     public SubmitChatExecutionResponse submitAgentChatExecution(final UUID agentId,
                                                                 final ChatAgentRequest request,
                                                                 final String idempotencyKey) {
-        final ChatAgentRequestDTO requestDTO = this.chatAgentClientMapper.asChatAgentRequestDto(request);
-        final SubmitChatExecutionResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentChatApi.submitAgentChatExecutionByExecutionsPath(agentId, requestDTO, idempotencyKey)
-        );
-        return this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO);
+        return this.agentChatAtmssoxClient.submitAgentChatExecution(agentId, request, idempotencyKey);
     }
 
     @Override
     public ChatExecution getAgentChatExecution(final UUID agentId, final UUID executionId, final UUID conversationId) {
-        final ChatExecutionDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentChatApi.getAgentChatExecution(agentId, executionId, conversationId)
-        );
-        return this.chatAgentClientMapper.asChatExecution(responseDTO);
+        return this.agentChatAtmssoxClient.getAgentChatExecution(agentId, executionId, conversationId);
     }
 
     @Override
     public Agent patchAgent(final UUID agentId, final PatchAgentRequest request) {
-        final PatchAgentRequestDTO requestDTO = this.patchAgentClientMapper.asPatchAgentRequestDto(request);
-        final AgentDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.patchAgent(agentId, requestDTO)
-        );
-        return this.agentClientMapper.asAgent(responseDTO);
+        return this.agentAtmssoxClient.patchAgent(agentId, request);
     }
-
 }

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentClientImpl.java
@@ -1,6 +1,10 @@
 package com.sitionix.bffssox.client;
 
 import com.app_afesox.atmssox.client.api.AgentApi;
+import com.app_afesox.atmssox.client.api.AgentChatApi;
+import com.app_afesox.atmssox.client.api.AgentConversationApi;
+import com.app_afesox.atmssox.client.api.AgentProjectApi;
+import com.app_afesox.atmssox.client.api.AgentRuleApi;
 import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.SubmitChatExecutionResponseDTO;
@@ -55,6 +59,10 @@ import org.springframework.stereotype.Service;
 public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient {
 
     private final AgentApi agentApi;
+    private final AgentProjectApi agentProjectApi;
+    private final AgentConversationApi agentConversationApi;
+    private final AgentRuleApi agentRuleApi;
+    private final AgentChatApi agentChatApi;
 
     private final CreateAgentClientMapper createAgentClientMapper;
     private final CreateAgentProjectClientMapper createAgentProjectClientMapper;
@@ -82,7 +90,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     public AgentProject createAgentProject(final CreateAgentProjectRequest request) {
         final CreateAgentProjectRequestDTO requestDTO = this.createAgentProjectClientMapper.asCreateAgentProjectRequestDto(request);
         final AgentProjectDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.createAgentProject(requestDTO)
+                () -> this.agentProjectApi.createAgentProject(requestDTO)
         );
         return this.agentClientMapper.asAgentProject(responseDTO);
     }
@@ -96,7 +104,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public AgentProjectsPageResponse getAgentProjects(final Integer page, final Integer size) {
         final AgentProjectsPageResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentProjects(page, size)
+                () -> this.agentProjectApi.getAgentProjects(page, size)
         );
         return this.agentClientMapper.asAgentProjectsPageResponse(responseDTO);
     }
@@ -104,7 +112,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public AgentProject getAgentProject(final UUID projectId) {
         final AgentProjectDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentProject(projectId)
+                () -> this.agentProjectApi.getAgentProject(projectId)
         );
         return this.agentClientMapper.asAgentProject(responseDTO);
     }
@@ -120,7 +128,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public AgentConversationsResponse getAgentConversations(final UUID agentId) {
         final AgentConversationsResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentConversations(agentId)
+                () -> this.agentConversationApi.getAgentConversations(agentId)
         );
         return this.chatAgentClientMapper.asAgentConversationsResponse(responseDTO);
     }
@@ -128,7 +136,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public AgentConversationDetails getAgentConversation(final UUID conversationId) {
         final AgentConversationDetailsDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentConversation(conversationId)
+                () -> this.agentConversationApi.getAgentConversation(conversationId)
         );
         return this.chatAgentClientMapper.asAgentConversationDetails(responseDTO);
     }
@@ -137,7 +145,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     public void deleteAgentConversation(final UUID conversationId) {
         this.atmssoxClientCallExecutor.execute(
                 () -> {
-                    this.agentApi.deleteAgentConversation(conversationId);
+                    this.agentConversationApi.deleteAgentConversation(conversationId);
                     return null;
                 }
         );
@@ -182,7 +190,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
                 ? null
                 : AgentRuleAuthorTypeDTO.fromValue(query.authorType());
         final AgentRulesResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentRules(agentId, status, authorType)
+                () -> this.agentRuleApi.getAgentRules(agentId, status, authorType)
         );
         return this.agentRuleClientMapper.asAgentRulesResponse(responseDTO);
     }
@@ -191,7 +199,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     public AgentRule createAgentRule(final UUID agentId, final CreateAgentRuleRequest request) {
         final CreateAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asCreateAgentRuleRequestDto(request);
         final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.createAgentRule(agentId, requestDTO)
+                () -> this.agentRuleApi.createAgentRule(agentId, requestDTO)
         );
         return this.agentRuleClientMapper.asAgentRule(responseDTO);
     }
@@ -200,7 +208,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     public AgentRule patchAgentRule(final UUID agentId, final UUID ruleId, final PatchAgentRuleRequest request) {
         final PatchAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asPatchAgentRuleRequestDto(request);
         final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.patchAgentRule(agentId, ruleId, requestDTO)
+                () -> this.agentRuleApi.patchAgentRule(agentId, ruleId, requestDTO)
         );
         return this.agentRuleClientMapper.asAgentRule(responseDTO);
     }
@@ -209,7 +217,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     public AgentRule acceptAgentRule(final UUID agentId, final UUID ruleId, final AcceptAgentRuleRequest request) {
         final AcceptAgentRuleRequestDTO requestDTO = request == null ? null : this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request);
         final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.acceptAgentRule(agentId, ruleId, requestDTO)
+                () -> this.agentRuleApi.acceptAgentRule(agentId, ruleId, requestDTO)
         );
         return this.agentRuleClientMapper.asAgentRule(responseDTO);
     }
@@ -217,7 +225,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public AgentRule rejectAgentRule(final UUID agentId, final UUID ruleId) {
         final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.rejectAgentRule(agentId, ruleId)
+                () -> this.agentRuleApi.rejectAgentRule(agentId, ruleId)
         );
         return this.agentRuleClientMapper.asAgentRule(responseDTO);
     }
@@ -225,7 +233,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public DeleteAgentRuleResponse deleteAgentRule(final UUID agentId, final UUID ruleId) {
         final DeleteAgentRuleResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.deleteAgentRule(agentId, ruleId)
+                () -> this.agentRuleApi.deleteAgentRule(agentId, ruleId)
         );
         return this.agentRuleClientMapper.asDeleteAgentRuleResponse(responseDTO);
     }
@@ -236,7 +244,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
                                                                 final String idempotencyKey) {
         final ChatAgentRequestDTO requestDTO = this.chatAgentClientMapper.asChatAgentRequestDto(request);
         final SubmitChatExecutionResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.submitAgentChatExecutionByExecutionsPath(agentId, requestDTO, idempotencyKey)
+                () -> this.agentChatApi.submitAgentChatExecutionByExecutionsPath(agentId, requestDTO, idempotencyKey)
         );
         return this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO);
     }
@@ -244,7 +252,7 @@ public class AgentClientImpl implements com.sitionix.bffssox.client.AgentClient 
     @Override
     public ChatExecution getAgentChatExecution(final UUID agentId, final UUID executionId, final UUID conversationId) {
         final ChatExecutionDTO responseDTO = this.atmssoxClientCallExecutor.execute(
-                () -> this.agentApi.getAgentChatExecution(agentId, executionId, conversationId)
+                () -> this.agentChatApi.getAgentChatExecution(agentId, executionId, conversationId)
         );
         return this.chatAgentClientMapper.asChatExecution(responseDTO);
     }

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentConversationAtmssoxClient.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentConversationAtmssoxClient.java
@@ -1,0 +1,41 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentConversationApi;
+import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
+import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
+import com.sitionix.bffssox.domain.AgentConversationDetails;
+import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AgentConversationAtmssoxClient {
+
+    private final AgentConversationApi agentConversationApi;
+    private final ChatAgentClientMapper chatAgentClientMapper;
+    private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    public AgentConversationsResponse getAgentConversations(final UUID agentId) {
+        final AgentConversationsResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentConversationApi.getAgentConversations(agentId)
+        );
+        return this.chatAgentClientMapper.asAgentConversationsResponse(responseDTO);
+    }
+
+    public AgentConversationDetails getAgentConversation(final UUID conversationId) {
+        final AgentConversationDetailsDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentConversationApi.getAgentConversation(conversationId)
+        );
+        return this.chatAgentClientMapper.asAgentConversationDetails(responseDTO);
+    }
+
+    public void deleteAgentConversation(final UUID conversationId) {
+        this.atmssoxClientCallExecutor.execute(() -> {
+            this.agentConversationApi.deleteAgentConversation(conversationId);
+            return null;
+        });
+    }
+}

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClient.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClient.java
@@ -1,0 +1,42 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentProjectApi;
+import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectsPageResponseDTO;
+import com.app_afesox.atmssox.client.dto.CreateAgentProjectRequestDTO;
+import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
+import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
+import com.sitionix.bffssox.mapper.AgentClientMapper;
+import com.sitionix.bffssox.mapper.CreateAgentProjectClientMapper;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AgentProjectAtmssoxClient {
+
+    private final AgentProjectApi agentProjectApi;
+    private final CreateAgentProjectClientMapper createAgentProjectClientMapper;
+    private final AgentClientMapper agentClientMapper;
+    private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    public AgentProject createAgentProject(final CreateAgentProjectRequest request) {
+        final CreateAgentProjectRequestDTO requestDTO = this.createAgentProjectClientMapper.asCreateAgentProjectRequestDto(request);
+        final AgentProjectDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentProjectApi.createAgentProject(requestDTO));
+        return this.agentClientMapper.asAgentProject(responseDTO);
+    }
+
+    public AgentProjectsPageResponse getAgentProjects(final Integer page, final Integer size) {
+        final AgentProjectsPageResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentProjectApi.getAgentProjects(page, size)
+        );
+        return this.agentClientMapper.asAgentProjectsPageResponse(responseDTO);
+    }
+
+    public AgentProject getAgentProject(final UUID projectId) {
+        final AgentProjectDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentProjectApi.getAgentProject(projectId));
+        return this.agentClientMapper.asAgentProject(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentRuleAtmssoxClient.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentRuleAtmssoxClient.java
@@ -1,0 +1,76 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentRuleApi;
+import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
+import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
+import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
+import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
+import com.app_afesox.atmssox.client.dto.DeleteAgentRuleResponseDTO;
+import com.app_afesox.atmssox.client.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
+import com.sitionix.bffssox.domain.AgentRule;
+import com.sitionix.bffssox.domain.AgentRulesResponse;
+import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
+import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
+import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
+import com.sitionix.bffssox.mapper.AgentRuleClientMapper;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AgentRuleAtmssoxClient {
+
+    private final AgentRuleApi agentRuleApi;
+    private final AgentRuleClientMapper agentRuleClientMapper;
+    private final AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    public AgentRulesResponse getAgentRules(final UUID agentId, final GetAgentRulesQuery query) {
+        final AgentRuleStatusDTO status = query == null || query.status() == null ? null : AgentRuleStatusDTO.fromValue(query.status());
+        final AgentRuleAuthorTypeDTO authorType = query == null || query.authorType() == null
+                ? null
+                : AgentRuleAuthorTypeDTO.fromValue(query.authorType());
+        final AgentRulesResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentRuleApi.getAgentRules(agentId, status, authorType)
+        );
+        return this.agentRuleClientMapper.asAgentRulesResponse(responseDTO);
+    }
+
+    public AgentRule createAgentRule(final UUID agentId, final CreateAgentRuleRequest request) {
+        final CreateAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asCreateAgentRuleRequestDto(request);
+        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentRuleApi.createAgentRule(agentId, requestDTO));
+        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+    }
+
+    public AgentRule patchAgentRule(final UUID agentId, final UUID ruleId, final PatchAgentRuleRequest request) {
+        final PatchAgentRuleRequestDTO requestDTO = this.agentRuleClientMapper.asPatchAgentRuleRequestDto(request);
+        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentRuleApi.patchAgentRule(agentId, ruleId, requestDTO)
+        );
+        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+    }
+
+    public AgentRule acceptAgentRule(final UUID agentId, final UUID ruleId, final AcceptAgentRuleRequest request) {
+        final AcceptAgentRuleRequestDTO requestDTO = request == null ? null : this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request);
+        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentRuleApi.acceptAgentRule(agentId, ruleId, requestDTO)
+        );
+        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+    }
+
+    public AgentRule rejectAgentRule(final UUID agentId, final UUID ruleId) {
+        final AgentRuleDTO responseDTO = this.atmssoxClientCallExecutor.execute(() -> this.agentRuleApi.rejectAgentRule(agentId, ruleId));
+        return this.agentRuleClientMapper.asAgentRule(responseDTO);
+    }
+
+    public DeleteAgentRuleResponse deleteAgentRule(final UUID agentId, final UUID ruleId) {
+        final DeleteAgentRuleResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentRuleApi.deleteAgentRule(agentId, ruleId)
+        );
+        return this.agentRuleClientMapper.asDeleteAgentRuleResponse(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentAtmssoxClientTest.java
@@ -1,0 +1,105 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentApi;
+import com.app_afesox.atmssox.client.dto.AgentDTO;
+import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
+import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.CreateAgentRequest;
+import com.sitionix.bffssox.mapper.AgentClientMapper;
+import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
+import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentAtmssoxClientTest {
+
+    private AgentAtmssoxClient agentAtmssoxClient;
+
+    @Mock
+    private AgentApi agentApi;
+    @Mock
+    private CreateAgentClientMapper createAgentClientMapper;
+    @Mock
+    private PatchAgentClientMapper patchAgentClientMapper;
+    @Mock
+    private AgentClientMapper agentClientMapper;
+    @Mock
+    private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    @BeforeEach
+    void setUp() {
+        this.agentAtmssoxClient = new AgentAtmssoxClient(
+                this.agentApi,
+                this.createAgentClientMapper,
+                this.patchAgentClientMapper,
+                this.agentClientMapper,
+                this.atmssoxClientCallExecutor
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentApi, this.createAgentClientMapper, this.patchAgentClientMapper, this.agentClientMapper,
+                this.atmssoxClientCallExecutor);
+    }
+
+    @Test
+    void givenCreateAgentRequest_whenCreateAgent_thenReturnMappedAgent() {
+        //given
+        final CreateAgentRequest request = mock(CreateAgentRequest.class);
+        final CreateAgentRequestDTO requestDTO = mock(CreateAgentRequestDTO.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final Agent expected = mock(Agent.class);
+        when(this.createAgentClientMapper.asCreateAgentRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentDTO>) invocation.getArgument(0)).get());
+        when(this.agentApi.createAgent(requestDTO)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+
+        //when
+        final Agent actual = this.agentAtmssoxClient.createAgent(request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.createAgentClientMapper).asCreateAgentRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).createAgent(requestDTO);
+        verify(this.agentClientMapper).asAgent(responseDTO);
+    }
+
+    @Test
+    void givenAgentIdAndPatchRequest_whenPatchAgent_thenReturnMappedAgent() {
+        //given
+        final java.util.UUID agentId = java.util.UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final com.sitionix.bffssox.domain.PatchAgentRequest request = mock(com.sitionix.bffssox.domain.PatchAgentRequest.class);
+        final com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO requestDTO = mock(com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO.class);
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final Agent expected = mock(Agent.class);
+        when(this.patchAgentClientMapper.asPatchAgentRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentDTO>) invocation.getArgument(0)).get());
+        when(this.agentApi.patchAgent(agentId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+
+        //when
+        final Agent actual = this.agentAtmssoxClient.patchAgent(agentId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.patchAgentClientMapper).asPatchAgentRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).patchAgent(agentId, requestDTO);
+        verify(this.agentClientMapper).asAgent(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentAtmssoxClientTest.java
@@ -2,12 +2,15 @@ package com.sitionix.bffssox.client;
 
 import com.app_afesox.atmssox.client.api.AgentApi;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
+import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
 import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import com.sitionix.bffssox.mapper.AgentClientMapper;
 import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
 import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -101,5 +105,60 @@ class AgentAtmssoxClientTest {
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentApi).patchAgent(agentId, requestDTO);
         verify(this.agentClientMapper).asAgent(responseDTO);
+    }
+
+    @Test
+    void givenNoInput_whenGetAgents_thenReturnMappedAgentsResponse() {
+        //given
+        final AgentsResponseDTO responseDTO = mock(AgentsResponseDTO.class);
+        final AgentsResponse expected = mock(AgentsResponse.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentsResponseDTO>) invocation.getArgument(0)).get());
+        when(this.agentApi.getAgents()).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgentsResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentsResponse actual = this.agentAtmssoxClient.getAgents();
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentApi).getAgents();
+        verify(this.agentClientMapper).asAgentsResponse(responseDTO);
+    }
+
+    @Test
+    void givenAgentId_whenGetActivateArchiveRestoreDelete_thenReturnMappedAgent() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final AgentDTO responseDTO = mock(AgentDTO.class);
+        final Agent expected = mock(Agent.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentDTO>) invocation.getArgument(0)).get());
+        when(this.agentApi.getAgent(agentId)).thenReturn(responseDTO);
+        when(this.agentApi.activateAgent(agentId)).thenReturn(responseDTO);
+        when(this.agentApi.archiveAgent(agentId)).thenReturn(responseDTO);
+        when(this.agentApi.restoreAgent(agentId)).thenReturn(responseDTO);
+        when(this.agentApi.deleteAgent(agentId)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+
+        //when
+        final Agent getResponse = this.agentAtmssoxClient.getAgent(agentId);
+        final Agent activateResponse = this.agentAtmssoxClient.activateAgent(agentId);
+        final Agent archiveResponse = this.agentAtmssoxClient.archiveAgent(agentId);
+        final Agent restoreResponse = this.agentAtmssoxClient.restoreAgent(agentId);
+        final Agent deleteResponse = this.agentAtmssoxClient.deleteAgent(agentId);
+
+        //then
+        assertThat(getResponse).isEqualTo(expected);
+        assertThat(activateResponse).isEqualTo(expected);
+        assertThat(archiveResponse).isEqualTo(expected);
+        assertThat(restoreResponse).isEqualTo(expected);
+        assertThat(deleteResponse).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor, times(5)).execute(any());
+        verify(this.agentApi).getAgent(agentId);
+        verify(this.agentApi).activateAgent(agentId);
+        verify(this.agentApi).archiveAgent(agentId);
+        verify(this.agentApi).restoreAgent(agentId);
+        verify(this.agentApi).deleteAgent(agentId);
+        verify(this.agentClientMapper, times(5)).asAgent(responseDTO);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentChatAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentChatAtmssoxClientTest.java
@@ -1,0 +1,73 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentChatApi;
+import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
+import com.app_afesox.atmssox.client.dto.SubmitChatExecutionResponseDTO;
+import com.sitionix.bffssox.domain.ChatAgentRequest;
+import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentChatAtmssoxClientTest {
+
+    private AgentChatAtmssoxClient agentChatAtmssoxClient;
+
+    @Mock
+    private AgentChatApi agentChatApi;
+    @Mock
+    private ChatAgentClientMapper chatAgentClientMapper;
+    @Mock
+    private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    @BeforeEach
+    void setUp() {
+        this.agentChatAtmssoxClient = new AgentChatAtmssoxClient(this.agentChatApi, this.chatAgentClientMapper, this.atmssoxClientCallExecutor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentChatApi, this.chatAgentClientMapper, this.atmssoxClientCallExecutor);
+    }
+
+    @Test
+    void givenChatRequest_whenSubmitAgentChatExecution_thenReturnMappedResponse() {
+        //given
+        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final ChatAgentRequest request = mock(ChatAgentRequest.class);
+        final ChatAgentRequestDTO requestDTO = mock(ChatAgentRequestDTO.class);
+        final SubmitChatExecutionResponseDTO responseDTO = mock(SubmitChatExecutionResponseDTO.class);
+        final SubmitChatExecutionResponse expected = mock(SubmitChatExecutionResponse.class);
+
+        when(this.chatAgentClientMapper.asChatAgentRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(
+                invocation -> ((Supplier<SubmitChatExecutionResponseDTO>) invocation.getArgument(0)).get()
+        );
+        when(this.agentChatApi.submitAgentChatExecutionByExecutionsPath(agentId, requestDTO, "idempotency-key")).thenReturn(responseDTO);
+        when(this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final SubmitChatExecutionResponse actual = this.agentChatAtmssoxClient.submitAgentChatExecution(agentId, request, "idempotency-key");
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentChatApi).submitAgentChatExecutionByExecutionsPath(agentId, requestDTO, "idempotency-key");
+        verify(this.chatAgentClientMapper).asSubmitChatExecutionResponse(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -1,57 +1,8 @@
 package com.sitionix.bffssox.client;
 
-import com.app_afesox.atmssox.client.api.AgentApi;
-import com.app_afesox.atmssox.client.api.AgentProjectApi;
-import com.app_afesox.atmssox.client.api.AgentConversationApi;
-import com.app_afesox.atmssox.client.api.AgentRuleApi;
-import com.app_afesox.atmssox.client.api.AgentChatApi;
-import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
-import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
-import com.app_afesox.atmssox.client.dto.AgentDTO;
-import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
-import com.app_afesox.atmssox.client.dto.AgentProjectsPageResponseDTO;
-import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
-import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
-import com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO;
-import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
-import com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO;
-import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
-import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
-import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
-import com.app_afesox.atmssox.client.dto.CreateAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.CreateAgentProjectRequestDTO;
-import com.app_afesox.atmssox.client.dto.DeleteAgentRuleResponseDTO;
-import com.app_afesox.atmssox.client.dto.PatchAgentRuleRequestDTO;
-import com.app_afesox.atmssox.client.dto.PatchAgentRequestDTO;
-import com.app_afesox.atmssox.client.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
-import com.sitionix.bffssox.domain.AgentConversationDetails;
-import com.sitionix.bffssox.domain.AgentConversationsResponse;
-import com.sitionix.bffssox.domain.AgentProject;
-import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
-import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
-import com.sitionix.bffssox.domain.AgentRule;
-import com.sitionix.bffssox.domain.AgentRulesResponse;
-import com.sitionix.bffssox.domain.AgentsResponse;
-import com.sitionix.bffssox.domain.ChatExecution;
-import com.sitionix.bffssox.domain.ChatAgentRequest;
-import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
-import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
-import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
-import com.sitionix.bffssox.domain.GetAgentRulesQuery;
-import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
-import com.sitionix.bffssox.domain.PatchAgentRequest;
-import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
-import com.sitionix.bffssox.mapper.AgentClientMapper;
-import com.sitionix.bffssox.mapper.AgentRuleClientMapper;
-import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
-import com.sitionix.bffssox.mapper.CreateAgentClientMapper;
-import com.sitionix.bffssox.mapper.CreateAgentProjectClientMapper;
-import com.sitionix.bffssox.mapper.PatchAgentClientMapper;
 import java.util.UUID;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,9 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -71,740 +19,119 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AgentClientImplTest {
 
-    private AgentClient agentClient;
+    private AgentClientImpl agentClient;
 
     @Mock
-    private AgentApi agentApi;
+    private AgentAtmssoxClient agentAtmssoxClient;
     @Mock
-    private AgentProjectApi agentProjectApi;
+    private AgentProjectAtmssoxClient agentProjectAtmssoxClient;
     @Mock
-    private AgentConversationApi agentConversationApi;
+    private AgentConversationAtmssoxClient agentConversationAtmssoxClient;
     @Mock
-    private AgentRuleApi agentRuleApi;
+    private AgentRuleAtmssoxClient agentRuleAtmssoxClient;
     @Mock
-    private AgentChatApi agentChatApi;
-
-    @Mock
-    private CreateAgentClientMapper createAgentClientMapper;
-    @Mock
-    private CreateAgentProjectClientMapper createAgentProjectClientMapper;
-
-    @Mock
-    private AgentClientMapper agentClientMapper;
-
-    @Mock
-    private AgentRuleClientMapper agentRuleClientMapper;
-
-    @Mock
-    private PatchAgentClientMapper patchAgentClientMapper;
-
-    @Mock
-    private ChatAgentClientMapper chatAgentClientMapper;
-    @Mock
-    private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+    private AgentChatAtmssoxClient agentChatAtmssoxClient;
 
     @BeforeEach
     void setUp() {
         this.agentClient = new AgentClientImpl(
-                this.agentApi,
-                this.agentProjectApi,
-                this.agentConversationApi,
-                this.agentRuleApi,
-                this.agentChatApi,
-                this.createAgentClientMapper,
-                this.createAgentProjectClientMapper,
-                this.agentClientMapper,
-                this.agentRuleClientMapper,
-                this.patchAgentClientMapper,
-                this.chatAgentClientMapper,
-                this.atmssoxClientCallExecutor
+                this.agentAtmssoxClient,
+                this.agentProjectAtmssoxClient,
+                this.agentConversationAtmssoxClient,
+                this.agentRuleAtmssoxClient,
+                this.agentChatAtmssoxClient
         );
     }
 
     @AfterEach
     void tearDown() {
         verifyNoMoreInteractions(
-                this.agentApi,
-                this.agentProjectApi,
-                this.agentConversationApi,
-                this.agentRuleApi,
-                this.agentChatApi,
-                this.agentProjectApi,
-                this.agentConversationApi,
-                this.agentRuleApi,
-                this.agentChatApi,
-                this.createAgentClientMapper,
-                this.createAgentProjectClientMapper,
-                this.agentClientMapper,
-                this.agentRuleClientMapper,
-                this.patchAgentClientMapper,
-                this.chatAgentClientMapper,
-                this.atmssoxClientCallExecutor
+                this.agentAtmssoxClient,
+                this.agentProjectAtmssoxClient,
+                this.agentConversationAtmssoxClient,
+                this.agentRuleAtmssoxClient,
+                this.agentChatAtmssoxClient
         );
     }
 
     @Test
-    void givenCreateAgentRequest_whenCreateAgent_thenReturnAgent() {
+    void givenCreateRequest_whenCreateAgent_thenDelegateToAgentClient() {
         //given
         final CreateAgentRequest request = mock(CreateAgentRequest.class);
-        final CreateAgentRequestDTO requestDTO = mock(CreateAgentRequestDTO.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent response = mock(Agent.class);
-
-        when(this.createAgentClientMapper.asCreateAgentRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.createAgent(requestDTO)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(response);
+        final Agent expected = mock(Agent.class);
+        when(this.agentAtmssoxClient.createAgent(request)).thenReturn(expected);
 
         //when
         final Agent actual = this.agentClient.createAgent(request);
 
         //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.createAgentClientMapper).asCreateAgentRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).createAgent(requestDTO);
-        verify(this.agentClientMapper).asAgent(responseDTO);
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentAtmssoxClient).createAgent(request);
     }
 
     @Test
-    void givenCreateAgentProjectRequest_whenCreateAgentProject_thenReturnAgentProject() {
+    void givenProjectPaging_whenGetAgentProjects_thenDelegateToProjectClient() {
         //given
-        final CreateAgentProjectRequest request = mock(CreateAgentProjectRequest.class);
-        final CreateAgentProjectRequestDTO requestDTO = mock(CreateAgentProjectRequestDTO.class);
-        final AgentProjectDTO responseDTO = mock(AgentProjectDTO.class);
-        final AgentProject response = mock(AgentProject.class);
-
-        when(this.createAgentProjectClientMapper.asCreateAgentProjectRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentProjectDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentProjectApi.createAgentProject(requestDTO)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgentProject(responseDTO)).thenReturn(response);
+        when(this.agentProjectAtmssoxClient.getAgentProjects(1, 20)).thenReturn(mock(com.sitionix.bffssox.domain.AgentProjectsPageResponse.class));
 
         //when
-        final AgentProject actual = this.agentClient.createAgentProject(request);
+        this.agentClient.getAgentProjects(1, 20);
 
         //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.createAgentProjectClientMapper).asCreateAgentProjectRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentProjectApi).createAgentProject(requestDTO);
-        verify(this.agentClientMapper).asAgentProject(responseDTO);
+        verify(this.agentProjectAtmssoxClient).getAgentProjects(1, 20);
     }
 
     @Test
-    void givenGetAgentsRequest_whenGetAgents_thenReturnAgentsResponse() {
-        //given
-        final AgentsResponseDTO responseDTO = mock(AgentsResponseDTO.class);
-        final AgentsResponse response = mock(AgentsResponse.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentsResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.getAgents()).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgentsResponse(responseDTO)).thenReturn(response);
-
-        //when
-        final AgentsResponse actual = this.agentClient.getAgents();
-
-        //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgents();
-        verify(this.agentClientMapper).asAgentsResponse(responseDTO);
-    }
-
-    @Test
-    void givenGetAgentProjectsRequest_whenGetAgentProjects_thenReturnAgentProjectsPageResponse() {
-        //given
-        final AgentProjectsPageResponseDTO responseDTO = mock(AgentProjectsPageResponseDTO.class);
-        final AgentProjectsPageResponse response = mock(AgentProjectsPageResponse.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentProjectsPageResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentProjectApi.getAgentProjects(1, 20)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgentProjectsPageResponse(responseDTO)).thenReturn(response);
-
-        //when
-        final AgentProjectsPageResponse actual = this.agentClient.getAgentProjects(1, 20);
-
-        //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentProjectApi).getAgentProjects(1, 20);
-        verify(this.agentClientMapper).asAgentProjectsPageResponse(responseDTO);
-    }
-
-    @Test
-    void givenProjectId_whenGetAgentProject_thenReturnAgentProject() {
-        //given
-        final UUID projectId = UUID.fromString("2d76e53b-f5f2-41d0-bbfd-4b26c9de5efe");
-        final AgentProjectDTO responseDTO = mock(AgentProjectDTO.class);
-        final AgentProject response = mock(AgentProject.class);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentProjectDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentProjectApi.getAgentProject(projectId)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgentProject(responseDTO)).thenReturn(response);
-
-        //when
-        final AgentProject actual = this.agentClient.getAgentProject(projectId);
-
-        //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentProjectApi).getAgentProject(projectId);
-        verify(this.agentClientMapper).asAgentProject(responseDTO);
-    }
-
-    @Test
-    void givenAgentId_whenGetAgent_thenReturnAgent() {
-        //given
-        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent response = mock(Agent.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.getAgent(agentId)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(response);
-
-        //when
-        final Agent actual = this.agentClient.getAgent(agentId);
-
-        //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgent(agentId);
-        verify(this.agentClientMapper).asAgent(responseDTO);
-    }
-
-    @Test
-    void givenAgentId_whenGetAgentConversations_thenReturnAgentConversationsResponse() {
-        //given
-        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
-        final AgentConversationsResponseDTO responseDTO = mock(AgentConversationsResponseDTO.class);
-        final AgentConversationsResponse response = mock(AgentConversationsResponse.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentConversationsResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentConversationApi.getAgentConversations(agentId)).thenReturn(responseDTO);
-        when(this.chatAgentClientMapper.asAgentConversationsResponse(responseDTO)).thenReturn(response);
-
-        //when
-        final AgentConversationsResponse actual = this.agentClient.getAgentConversations(agentId);
-
-        //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentConversationApi).getAgentConversations(agentId);
-        verify(this.chatAgentClientMapper).asAgentConversationsResponse(responseDTO);
-    }
-
-    @Test
-    void givenConversationId_whenGetAgentConversation_thenReturnAgentConversationDetails() {
+    void givenConversationId_whenDeleteAgentConversation_thenDelegateToConversationClient() {
         //given
         final UUID conversationId = UUID.fromString("cab3fa9e-c59f-47cb-8627-1c19698ef5f3");
-        final AgentConversationDetailsDTO responseDTO = mock(AgentConversationDetailsDTO.class);
-        final AgentConversationDetails response = mock(AgentConversationDetails.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentConversationDetailsDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentConversationApi.getAgentConversation(conversationId)).thenReturn(responseDTO);
-        when(this.chatAgentClientMapper.asAgentConversationDetails(responseDTO)).thenReturn(response);
-
-        //when
-        final AgentConversationDetails actual = this.agentClient.getAgentConversation(conversationId);
-
-        //then
-        assertThat(actual).isEqualTo(response);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentConversationApi).getAgentConversation(conversationId);
-        verify(this.chatAgentClientMapper).asAgentConversationDetails(responseDTO);
-    }
-
-    @Test
-    void givenConversationId_whenDeleteAgentConversation_thenCallDownstreamDelete() {
-        //given
-        final UUID conversationId = UUID.fromString("34ce1743-04f0-4066-8fbe-4f965e4b4904");
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<Void> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
 
         //when
         this.agentClient.deleteAgentConversation(conversationId);
 
         //then
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentConversationApi).deleteAgentConversation(conversationId);
+        verify(this.agentConversationAtmssoxClient).deleteAgentConversation(conversationId);
     }
 
     @Test
-    void givenPatchAgentRequest_whenPatchAgent_thenReturnAgent() {
+    void givenQuery_whenGetAgentRules_thenDelegateToRuleClient() {
         //given
-        final UUID givenAgentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
-        final PatchAgentRequest request = mock(PatchAgentRequest.class);
-        final PatchAgentRequestDTO requestDTO = mock(PatchAgentRequestDTO.class);
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent expected = mock(Agent.class);
-
-        when(this.patchAgentClientMapper.asPatchAgentRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.patchAgent(givenAgentId, requestDTO)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final com.sitionix.bffssox.domain.GetAgentRulesQuery query = mock(com.sitionix.bffssox.domain.GetAgentRulesQuery.class);
+        when(this.agentRuleAtmssoxClient.getAgentRules(agentId, query)).thenReturn(mock(com.sitionix.bffssox.domain.AgentRulesResponse.class));
 
         //when
-        final Agent actual = this.agentClient.patchAgent(givenAgentId, request);
+        this.agentClient.getAgentRules(agentId, query);
 
         //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.patchAgentClientMapper).asPatchAgentRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).patchAgent(givenAgentId, requestDTO);
-        verify(this.agentClientMapper).asAgent(responseDTO);
+        verify(this.agentRuleAtmssoxClient).getAgentRules(agentId, query);
     }
 
     @Test
-    void givenAgentId_whenActivateAgent_thenReturnAgent() {
+    void givenChatRequest_whenSubmitChatExecution_thenDelegateToChatClient() {
         //given
-        final UUID givenAgentId = UUID.fromString("88e2673a-273a-4cf4-a94f-96f4df311ea9");
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent expected = mock(Agent.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.activateAgent(givenAgentId)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final com.sitionix.bffssox.domain.ChatAgentRequest request = mock(com.sitionix.bffssox.domain.ChatAgentRequest.class);
+        when(this.agentChatAtmssoxClient.submitAgentChatExecution(agentId, request, "idempotency")).thenReturn(mock(com.sitionix.bffssox.domain.SubmitChatExecutionResponse.class));
 
         //when
-        final Agent actual = this.agentClient.activateAgent(givenAgentId);
+        this.agentClient.submitAgentChatExecution(agentId, request, "idempotency");
 
         //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).activateAgent(givenAgentId);
-        verify(this.agentClientMapper).asAgent(responseDTO);
+        verify(this.agentChatAtmssoxClient).submitAgentChatExecution(agentId, request, "idempotency");
     }
 
     @Test
-    void givenAgentId_whenArchiveAgent_thenReturnAgent() {
+    void givenPatchRequest_whenPatchAgent_thenDelegateToAgentClient() {
         //given
-        final UUID givenAgentId = UUID.fromString("f8f58985-8fa8-4412-8f1e-7955f0f8f85e");
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent expected = mock(Agent.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.archiveAgent(givenAgentId)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
+        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final com.sitionix.bffssox.domain.PatchAgentRequest request = mock(com.sitionix.bffssox.domain.PatchAgentRequest.class);
+        when(this.agentAtmssoxClient.patchAgent(agentId, request)).thenReturn(mock(Agent.class));
 
         //when
-        final Agent actual = this.agentClient.archiveAgent(givenAgentId);
+        this.agentClient.patchAgent(agentId, request);
 
         //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).archiveAgent(givenAgentId);
-        verify(this.agentClientMapper).asAgent(responseDTO);
-    }
-
-    @Test
-    void givenAgentId_whenRestoreAgent_thenReturnAgent() {
-        //given
-        final UUID givenAgentId = UUID.fromString("c1db6b3a-2ee2-4f59-889b-ec3e8e343973");
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent expected = mock(Agent.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.restoreAgent(givenAgentId)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
-
-        //when
-        final Agent actual = this.agentClient.restoreAgent(givenAgentId);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).restoreAgent(givenAgentId);
-        verify(this.agentClientMapper).asAgent(responseDTO);
-    }
-
-    @Test
-    void givenAgentId_whenDeleteAgent_thenReturnAgent() {
-        //given
-        final UUID givenAgentId = UUID.fromString("78ad5fab-af5a-4667-a150-33970a9f72b0");
-        final AgentDTO responseDTO = mock(AgentDTO.class);
-        final Agent expected = mock(Agent.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentApi.deleteAgent(givenAgentId)).thenReturn(responseDTO);
-        when(this.agentClientMapper.asAgent(responseDTO)).thenReturn(expected);
-
-        //when
-        final Agent actual = this.agentClient.deleteAgent(givenAgentId);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).deleteAgent(givenAgentId);
-        verify(this.agentClientMapper).asAgent(responseDTO);
-    }
-
-    @Test
-    void givenChatAgentRequest_whenSubmitAgentChatExecution_thenReturnExecutionAck() {
-        //given
-        final UUID givenAgentId = UUID.fromString("7ac2f8c1-3d66-4cb4-95d9-27df5c66bf20");
-        final UUID clientRequestId = UUID.fromString("8ecef151-3f6a-46a8-a9a4-1f61f65b6f09");
-        final ChatAgentRequest request = mock(ChatAgentRequest.class);
-        final ChatAgentRequestDTO requestDTO = this.getChatAgentRequestDto(clientRequestId);
-        final SubmitChatExecutionResponseDTO responseDTO = mock(SubmitChatExecutionResponseDTO.class);
-        final SubmitChatExecutionResponse expected = mock(SubmitChatExecutionResponse.class);
-
-        when(this.chatAgentClientMapper.asChatAgentRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<SubmitChatExecutionResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentChatApi.submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, "idem-key")).thenReturn(responseDTO);
-        when(this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO)).thenReturn(expected);
-
-        //when
-        final SubmitChatExecutionResponse actual = this.agentClient.submitAgentChatExecution(givenAgentId, request, "idem-key");
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentChatApi).submitAgentChatExecutionByExecutionsPath(
-                eq(givenAgentId),
-                argThat(dto -> dto != null && clientRequestId.equals(dto.getClientRequestId())),
-                eq("idem-key")
-        );
-        verify(this.chatAgentClientMapper).asSubmitChatExecutionResponse(responseDTO);
-    }
-
-    private ChatAgentRequestDTO getChatAgentRequestDto(final UUID clientRequestId) {
-        return ChatAgentRequestDTO.builder()
-                .clientRequestId(clientRequestId)
-                .message("message")
-                .build();
-    }
-
-    @Test
-    void givenChatAgentRequestAndNullIdempotencyKey_whenSubmitAgentChatExecution_thenDoNotSendIdempotencyHeader() {
-        //given
-        final UUID givenAgentId = UUID.fromString("7ac2f8c1-3d66-4cb4-95d9-27df5c66bf20");
-        final ChatAgentRequest request = mock(ChatAgentRequest.class);
-        final ChatAgentRequestDTO requestDTO = mock(ChatAgentRequestDTO.class);
-        final SubmitChatExecutionResponseDTO responseDTO = mock(SubmitChatExecutionResponseDTO.class);
-        final SubmitChatExecutionResponse expected = mock(SubmitChatExecutionResponse.class);
-
-        when(this.chatAgentClientMapper.asChatAgentRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<SubmitChatExecutionResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentChatApi.submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, null)).thenReturn(responseDTO);
-        when(this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO)).thenReturn(expected);
-
-        //when
-        final SubmitChatExecutionResponse actual = this.agentClient.submitAgentChatExecution(givenAgentId, request, null);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentChatApi).submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, null);
-        verify(this.chatAgentClientMapper).asSubmitChatExecutionResponse(responseDTO);
-    }
-
-    @Test
-    void givenExecutionIdentifiers_whenGetAgentChatExecution_thenReturnExecution() {
-        //given
-        final UUID givenAgentId = UUID.fromString("7ac2f8c1-3d66-4cb4-95d9-27df5c66bf20");
-        final UUID givenExecutionId = UUID.fromString("f2a1e248-e001-486f-90d5-b69281eb2ec2");
-        final UUID givenConversationId = UUID.fromString("b6f2e9b0-1572-4e88-a430-bca8c7e6434f");
-        final ChatExecutionDTO responseDTO = mock(ChatExecutionDTO.class);
-        final ChatExecution expected = mock(ChatExecution.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<ChatExecutionDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentChatApi.getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId)).thenReturn(responseDTO);
-        when(this.chatAgentClientMapper.asChatExecution(responseDTO)).thenReturn(expected);
-
-        //when
-        final ChatExecution actual = this.agentClient.getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentChatApi).getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId);
-        verify(this.chatAgentClientMapper).asChatExecution(responseDTO);
-    }
-
-    @Test
-    void givenExecutionIdentifiersAndNullConversationId_whenGetAgentChatExecution_thenDoNotSendConversationQueryParam() {
-        //given
-        final UUID givenAgentId = UUID.fromString("7ac2f8c1-3d66-4cb4-95d9-27df5c66bf20");
-        final UUID givenExecutionId = UUID.fromString("f2a1e248-e001-486f-90d5-b69281eb2ec2");
-        final ChatExecutionDTO responseDTO = mock(ChatExecutionDTO.class);
-        final ChatExecution expected = mock(ChatExecution.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<ChatExecutionDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentChatApi.getAgentChatExecution(givenAgentId, givenExecutionId, null)).thenReturn(responseDTO);
-        when(this.chatAgentClientMapper.asChatExecution(responseDTO)).thenReturn(expected);
-
-        //when
-        final ChatExecution actual = this.agentClient.getAgentChatExecution(givenAgentId, givenExecutionId, null);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentChatApi).getAgentChatExecution(givenAgentId, givenExecutionId, null);
-        verify(this.chatAgentClientMapper).asChatExecution(responseDTO);
-    }
-
-    @Test
-    void givenAgentId_whenGetAgentRules_thenReturnAgentRulesResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("d9ac51e6-9711-40b8-b5bc-fbafdb9f8c08");
-        final GetAgentRulesQuery query = new GetAgentRulesQuery("ACTIVE", "AI");
-        final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
-        final AgentRulesResponse expected = mock(AgentRulesResponse.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRulesResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRulesResponse actual = this.agentClient.getAgentRules(givenAgentId, query);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI);
-        verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
-    }
-
-    @Test
-    void givenAgentIdAndNullQuery_whenGetAgentRules_thenReturnAgentRulesResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("52418b95-6688-4c7e-a7ef-08eeceddd153");
-        final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
-        final AgentRulesResponse expected = mock(AgentRulesResponse.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRulesResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.getAgentRules(givenAgentId, null, null)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRulesResponse actual = this.agentClient.getAgentRules(givenAgentId, null);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).getAgentRules(givenAgentId, null, null);
-        verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
-    }
-
-    @Test
-    void givenAgentIdAndRuleRequest_whenCreateAgentRule_thenReturnAgentRule() {
-        //given
-        final UUID givenAgentId = UUID.fromString("fc22a352-fcc8-4765-a9f8-959518f0689f");
-        final CreateAgentRuleRequest request = mock(CreateAgentRuleRequest.class);
-        final CreateAgentRuleRequestDTO requestDTO = mock(CreateAgentRuleRequestDTO.class);
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-        final AgentRule expected = mock(AgentRule.class);
-
-        when(this.agentRuleClientMapper.asCreateAgentRuleRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.createAgentRule(givenAgentId, requestDTO)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRule actual = this.agentClient.createAgentRule(givenAgentId, request);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.agentRuleClientMapper).asCreateAgentRuleRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).createAgentRule(givenAgentId, requestDTO);
-        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
-    }
-
-    @Test
-    void givenAgentAndRuleIdsAndPatchRequest_whenPatchAgentRule_thenReturnAgentRule() {
-        //given
-        final UUID givenAgentId = UUID.fromString("e71cf5eb-35fa-46e2-b75d-8094c2af4e4a");
-        final UUID givenRuleId = UUID.fromString("6700e0eb-f6de-4f4d-9a3f-f40eabfe7f2c");
-        final PatchAgentRuleRequest request = mock(PatchAgentRuleRequest.class);
-        final PatchAgentRuleRequestDTO requestDTO = mock(PatchAgentRuleRequestDTO.class);
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-        final AgentRule expected = mock(AgentRule.class);
-
-        when(this.agentRuleClientMapper.asPatchAgentRuleRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.patchAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRule actual = this.agentClient.patchAgentRule(givenAgentId, givenRuleId, request);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.agentRuleClientMapper).asPatchAgentRuleRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).patchAgentRule(givenAgentId, givenRuleId, requestDTO);
-        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
-    }
-
-    @Test
-    void givenAgentAndRuleIdsAndNullAcceptRequest_whenAcceptAgentRule_thenReturnAgentRule() {
-        //given
-        final UUID givenAgentId = UUID.fromString("92456ccf-6595-4f4a-88f7-5f9ed79046fe");
-        final UUID givenRuleId = UUID.fromString("e2b9d7cb-f69a-405d-b44f-e95dbd7e08ee");
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-        final AgentRule expected = mock(AgentRule.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.acceptAgentRule(givenAgentId, givenRuleId, null)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRule actual = this.agentClient.acceptAgentRule(givenAgentId, givenRuleId, null);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).acceptAgentRule(givenAgentId, givenRuleId, null);
-        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
-    }
-
-    @Test
-    void givenAgentAndRuleIdsAndAcceptRequest_whenAcceptAgentRule_thenReturnAgentRule() {
-        //given
-        final UUID givenAgentId = UUID.fromString("f46cd205-0809-4fd3-832f-3358f71339df");
-        final UUID givenRuleId = UUID.fromString("c22311b0-5b92-4d98-b04e-eb2fbe34f8ca");
-        final AcceptAgentRuleRequest request = mock(AcceptAgentRuleRequest.class);
-        final AcceptAgentRuleRequestDTO requestDTO = mock(AcceptAgentRuleRequestDTO.class);
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-        final AgentRule expected = mock(AgentRule.class);
-
-        when(this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request)).thenReturn(requestDTO);
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.acceptAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRule actual = this.agentClient.acceptAgentRule(givenAgentId, givenRuleId, request);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.agentRuleClientMapper).asAcceptAgentRuleRequestDto(request);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).acceptAgentRule(givenAgentId, givenRuleId, requestDTO);
-        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
-    }
-
-    @Test
-    void givenAgentAndRuleIds_whenRejectAgentRule_thenReturnAgentRule() {
-        //given
-        final UUID givenAgentId = UUID.fromString("465cd2f0-2dd5-4847-bd99-f6bfd8c7f331");
-        final UUID givenRuleId = UUID.fromString("60af08a3-0a29-4f27-8a74-f0f29695f90c");
-        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
-        final AgentRule expected = mock(AgentRule.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.rejectAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
-
-        //when
-        final AgentRule actual = this.agentClient.rejectAgentRule(givenAgentId, givenRuleId);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).rejectAgentRule(givenAgentId, givenRuleId);
-        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
-    }
-
-    @Test
-    void givenAgentAndRuleIds_whenDeleteAgentRule_thenReturnDeleteAgentRuleResponse() {
-        //given
-        final UUID givenAgentId = UUID.fromString("46e63917-16f9-4f89-a589-af57209dae6d");
-        final UUID givenRuleId = UUID.fromString("e644fd69-b71a-4600-8e3f-2ec99b0afab0");
-        final DeleteAgentRuleResponseDTO responseDTO = mock(DeleteAgentRuleResponseDTO.class);
-        final DeleteAgentRuleResponse expected = mock(DeleteAgentRuleResponse.class);
-
-        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> {
-            final Supplier<DeleteAgentRuleResponseDTO> supplier = invocation.getArgument(0);
-            return supplier.get();
-        });
-        when(this.agentRuleApi.deleteAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
-        when(this.agentRuleClientMapper.asDeleteAgentRuleResponse(responseDTO)).thenReturn(expected);
-
-        //when
-        final DeleteAgentRuleResponse actual = this.agentClient.deleteAgentRule(givenAgentId, givenRuleId);
-
-        //then
-        assertThat(actual).isEqualTo(expected);
-        verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentRuleApi).deleteAgentRule(givenAgentId, givenRuleId);
-        verify(this.agentRuleClientMapper).asDeleteAgentRuleResponse(responseDTO);
+        verify(this.agentAtmssoxClient).patchAgent(agentId, request);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -1,6 +1,10 @@
 package com.sitionix.bffssox.client;
 
 import com.app_afesox.atmssox.client.api.AgentApi;
+import com.app_afesox.atmssox.client.api.AgentProjectApi;
+import com.app_afesox.atmssox.client.api.AgentConversationApi;
+import com.app_afesox.atmssox.client.api.AgentRuleApi;
+import com.app_afesox.atmssox.client.api.AgentChatApi;
 import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentDTO;
@@ -71,6 +75,14 @@ class AgentClientImplTest {
 
     @Mock
     private AgentApi agentApi;
+    @Mock
+    private AgentProjectApi agentProjectApi;
+    @Mock
+    private AgentConversationApi agentConversationApi;
+    @Mock
+    private AgentRuleApi agentRuleApi;
+    @Mock
+    private AgentChatApi agentChatApi;
 
     @Mock
     private CreateAgentClientMapper createAgentClientMapper;
@@ -95,6 +107,10 @@ class AgentClientImplTest {
     void setUp() {
         this.agentClient = new AgentClientImpl(
                 this.agentApi,
+                this.agentProjectApi,
+                this.agentConversationApi,
+                this.agentRuleApi,
+                this.agentChatApi,
                 this.createAgentClientMapper,
                 this.createAgentProjectClientMapper,
                 this.agentClientMapper,
@@ -109,6 +125,14 @@ class AgentClientImplTest {
     void tearDown() {
         verifyNoMoreInteractions(
                 this.agentApi,
+                this.agentProjectApi,
+                this.agentConversationApi,
+                this.agentRuleApi,
+                this.agentChatApi,
+                this.agentProjectApi,
+                this.agentConversationApi,
+                this.agentRuleApi,
+                this.agentChatApi,
                 this.createAgentClientMapper,
                 this.createAgentProjectClientMapper,
                 this.agentClientMapper,
@@ -159,7 +183,7 @@ class AgentClientImplTest {
             final Supplier<AgentProjectDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.createAgentProject(requestDTO)).thenReturn(responseDTO);
+        when(this.agentProjectApi.createAgentProject(requestDTO)).thenReturn(responseDTO);
         when(this.agentClientMapper.asAgentProject(responseDTO)).thenReturn(response);
 
         //when
@@ -169,7 +193,7 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(response);
         verify(this.createAgentProjectClientMapper).asCreateAgentProjectRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).createAgentProject(requestDTO);
+        verify(this.agentProjectApi).createAgentProject(requestDTO);
         verify(this.agentClientMapper).asAgentProject(responseDTO);
     }
 
@@ -206,7 +230,7 @@ class AgentClientImplTest {
             final Supplier<AgentProjectsPageResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentProjects(1, 20)).thenReturn(responseDTO);
+        when(this.agentProjectApi.getAgentProjects(1, 20)).thenReturn(responseDTO);
         when(this.agentClientMapper.asAgentProjectsPageResponse(responseDTO)).thenReturn(response);
 
         //when
@@ -215,7 +239,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(response);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentProjects(1, 20);
+        verify(this.agentProjectApi).getAgentProjects(1, 20);
         verify(this.agentClientMapper).asAgentProjectsPageResponse(responseDTO);
     }
 
@@ -229,7 +253,7 @@ class AgentClientImplTest {
             final Supplier<AgentProjectDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentProject(projectId)).thenReturn(responseDTO);
+        when(this.agentProjectApi.getAgentProject(projectId)).thenReturn(responseDTO);
         when(this.agentClientMapper.asAgentProject(responseDTO)).thenReturn(response);
 
         //when
@@ -238,7 +262,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(response);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentProject(projectId);
+        verify(this.agentProjectApi).getAgentProject(projectId);
         verify(this.agentClientMapper).asAgentProject(responseDTO);
     }
 
@@ -277,7 +301,7 @@ class AgentClientImplTest {
             final Supplier<AgentConversationsResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentConversations(agentId)).thenReturn(responseDTO);
+        when(this.agentConversationApi.getAgentConversations(agentId)).thenReturn(responseDTO);
         when(this.chatAgentClientMapper.asAgentConversationsResponse(responseDTO)).thenReturn(response);
 
         //when
@@ -286,7 +310,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(response);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentConversations(agentId);
+        verify(this.agentConversationApi).getAgentConversations(agentId);
         verify(this.chatAgentClientMapper).asAgentConversationsResponse(responseDTO);
     }
 
@@ -301,7 +325,7 @@ class AgentClientImplTest {
             final Supplier<AgentConversationDetailsDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentConversation(conversationId)).thenReturn(responseDTO);
+        when(this.agentConversationApi.getAgentConversation(conversationId)).thenReturn(responseDTO);
         when(this.chatAgentClientMapper.asAgentConversationDetails(responseDTO)).thenReturn(response);
 
         //when
@@ -310,7 +334,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(response);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentConversation(conversationId);
+        verify(this.agentConversationApi).getAgentConversation(conversationId);
         verify(this.chatAgentClientMapper).asAgentConversationDetails(responseDTO);
     }
 
@@ -328,7 +352,7 @@ class AgentClientImplTest {
 
         //then
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).deleteAgentConversation(conversationId);
+        verify(this.agentConversationApi).deleteAgentConversation(conversationId);
     }
 
     @Test
@@ -470,7 +494,7 @@ class AgentClientImplTest {
             final Supplier<SubmitChatExecutionResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, "idem-key")).thenReturn(responseDTO);
+        when(this.agentChatApi.submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, "idem-key")).thenReturn(responseDTO);
         when(this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO)).thenReturn(expected);
 
         //when
@@ -480,7 +504,7 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(expected);
         verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).submitAgentChatExecutionByExecutionsPath(
+        verify(this.agentChatApi).submitAgentChatExecutionByExecutionsPath(
                 eq(givenAgentId),
                 argThat(dto -> dto != null && clientRequestId.equals(dto.getClientRequestId())),
                 eq("idem-key")
@@ -509,7 +533,7 @@ class AgentClientImplTest {
             final Supplier<SubmitChatExecutionResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, null)).thenReturn(responseDTO);
+        when(this.agentChatApi.submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, null)).thenReturn(responseDTO);
         when(this.chatAgentClientMapper.asSubmitChatExecutionResponse(responseDTO)).thenReturn(expected);
 
         //when
@@ -519,7 +543,7 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(expected);
         verify(this.chatAgentClientMapper).asChatAgentRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, null);
+        verify(this.agentChatApi).submitAgentChatExecutionByExecutionsPath(givenAgentId, requestDTO, null);
         verify(this.chatAgentClientMapper).asSubmitChatExecutionResponse(responseDTO);
     }
 
@@ -536,7 +560,7 @@ class AgentClientImplTest {
             final Supplier<ChatExecutionDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId)).thenReturn(responseDTO);
+        when(this.agentChatApi.getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId)).thenReturn(responseDTO);
         when(this.chatAgentClientMapper.asChatExecution(responseDTO)).thenReturn(expected);
 
         //when
@@ -545,7 +569,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId);
+        verify(this.agentChatApi).getAgentChatExecution(givenAgentId, givenExecutionId, givenConversationId);
         verify(this.chatAgentClientMapper).asChatExecution(responseDTO);
     }
 
@@ -561,7 +585,7 @@ class AgentClientImplTest {
             final Supplier<ChatExecutionDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentChatExecution(givenAgentId, givenExecutionId, null)).thenReturn(responseDTO);
+        when(this.agentChatApi.getAgentChatExecution(givenAgentId, givenExecutionId, null)).thenReturn(responseDTO);
         when(this.chatAgentClientMapper.asChatExecution(responseDTO)).thenReturn(expected);
 
         //when
@@ -570,7 +594,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentChatExecution(givenAgentId, givenExecutionId, null);
+        verify(this.agentChatApi).getAgentChatExecution(givenAgentId, givenExecutionId, null);
         verify(this.chatAgentClientMapper).asChatExecution(responseDTO);
     }
 
@@ -586,7 +610,7 @@ class AgentClientImplTest {
             final Supplier<AgentRulesResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI)).thenReturn(responseDTO);
+        when(this.agentRuleApi.getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
 
         //when
@@ -595,7 +619,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI);
+        verify(this.agentRuleApi).getAgentRules(givenAgentId, AgentRuleStatusDTO.ACTIVE, AgentRuleAuthorTypeDTO.AI);
         verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
     }
 
@@ -610,7 +634,7 @@ class AgentClientImplTest {
             final Supplier<AgentRulesResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.getAgentRules(givenAgentId, null, null)).thenReturn(responseDTO);
+        when(this.agentRuleApi.getAgentRules(givenAgentId, null, null)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
 
         //when
@@ -619,7 +643,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).getAgentRules(givenAgentId, null, null);
+        verify(this.agentRuleApi).getAgentRules(givenAgentId, null, null);
         verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
     }
 
@@ -637,7 +661,7 @@ class AgentClientImplTest {
             final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.createAgentRule(givenAgentId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleApi.createAgentRule(givenAgentId, requestDTO)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
 
         //when
@@ -647,7 +671,7 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(expected);
         verify(this.agentRuleClientMapper).asCreateAgentRuleRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).createAgentRule(givenAgentId, requestDTO);
+        verify(this.agentRuleApi).createAgentRule(givenAgentId, requestDTO);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
     }
 
@@ -666,7 +690,7 @@ class AgentClientImplTest {
             final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.patchAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleApi.patchAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
 
         //when
@@ -676,7 +700,7 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(expected);
         verify(this.agentRuleClientMapper).asPatchAgentRuleRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).patchAgentRule(givenAgentId, givenRuleId, requestDTO);
+        verify(this.agentRuleApi).patchAgentRule(givenAgentId, givenRuleId, requestDTO);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
     }
 
@@ -692,7 +716,7 @@ class AgentClientImplTest {
             final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.acceptAgentRule(givenAgentId, givenRuleId, null)).thenReturn(responseDTO);
+        when(this.agentRuleApi.acceptAgentRule(givenAgentId, givenRuleId, null)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
 
         //when
@@ -701,7 +725,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).acceptAgentRule(givenAgentId, givenRuleId, null);
+        verify(this.agentRuleApi).acceptAgentRule(givenAgentId, givenRuleId, null);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
     }
 
@@ -720,7 +744,7 @@ class AgentClientImplTest {
             final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.acceptAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleApi.acceptAgentRule(givenAgentId, givenRuleId, requestDTO)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
 
         //when
@@ -730,7 +754,7 @@ class AgentClientImplTest {
         assertThat(actual).isEqualTo(expected);
         verify(this.agentRuleClientMapper).asAcceptAgentRuleRequestDto(request);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).acceptAgentRule(givenAgentId, givenRuleId, requestDTO);
+        verify(this.agentRuleApi).acceptAgentRule(givenAgentId, givenRuleId, requestDTO);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
     }
 
@@ -746,7 +770,7 @@ class AgentClientImplTest {
             final Supplier<AgentRuleDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.rejectAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
+        when(this.agentRuleApi.rejectAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
 
         //when
@@ -755,7 +779,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).rejectAgentRule(givenAgentId, givenRuleId);
+        verify(this.agentRuleApi).rejectAgentRule(givenAgentId, givenRuleId);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
     }
 
@@ -771,7 +795,7 @@ class AgentClientImplTest {
             final Supplier<DeleteAgentRuleResponseDTO> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        when(this.agentApi.deleteAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
+        when(this.agentRuleApi.deleteAgentRule(givenAgentId, givenRuleId)).thenReturn(responseDTO);
         when(this.agentRuleClientMapper.asDeleteAgentRuleResponse(responseDTO)).thenReturn(expected);
 
         //when
@@ -780,7 +804,7 @@ class AgentClientImplTest {
         //then
         assertThat(actual).isEqualTo(expected);
         verify(this.atmssoxClientCallExecutor).execute(any());
-        verify(this.agentApi).deleteAgentRule(givenAgentId, givenRuleId);
+        verify(this.agentRuleApi).deleteAgentRule(givenAgentId, givenRuleId);
         verify(this.agentRuleClientMapper).asDeleteAgentRuleResponse(responseDTO);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentClientImplTest.java
@@ -1,6 +1,15 @@
 package com.sitionix.bffssox.client;
 
 import com.sitionix.bffssox.domain.Agent;
+import com.sitionix.bffssox.domain.AgentConversationDetails;
+import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
+import com.sitionix.bffssox.domain.AgentRule;
+import com.sitionix.bffssox.domain.AgentsResponse;
+import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
+import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.domain.CreateAgentRequest;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -72,7 +81,7 @@ class AgentClientImplTest {
     @Test
     void givenProjectPaging_whenGetAgentProjects_thenDelegateToProjectClient() {
         //given
-        when(this.agentProjectAtmssoxClient.getAgentProjects(1, 20)).thenReturn(mock(com.sitionix.bffssox.domain.AgentProjectsPageResponse.class));
+        when(this.agentProjectAtmssoxClient.getAgentProjects(1, 20)).thenReturn(mock(AgentProjectsPageResponse.class));
 
         //when
         this.agentClient.getAgentProjects(1, 20);
@@ -97,7 +106,7 @@ class AgentClientImplTest {
     void givenQuery_whenGetAgentRules_thenDelegateToRuleClient() {
         //given
         final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
-        final com.sitionix.bffssox.domain.GetAgentRulesQuery query = mock(com.sitionix.bffssox.domain.GetAgentRulesQuery.class);
+        final GetAgentRulesQuery query = mock(GetAgentRulesQuery.class);
         when(this.agentRuleAtmssoxClient.getAgentRules(agentId, query)).thenReturn(mock(com.sitionix.bffssox.domain.AgentRulesResponse.class));
 
         //when
@@ -133,5 +142,112 @@ class AgentClientImplTest {
 
         //then
         verify(this.agentAtmssoxClient).patchAgent(agentId, request);
+    }
+
+    @Test
+    void givenIds_whenGetProjectAndConversation_thenDelegateToDedicatedClients() {
+        //given
+        final UUID projectId = UUID.randomUUID();
+        final UUID conversationId = UUID.randomUUID();
+        final AgentProject project = mock(AgentProject.class);
+        final AgentConversationDetails details = mock(AgentConversationDetails.class);
+        when(this.agentProjectAtmssoxClient.getAgentProject(projectId)).thenReturn(project);
+        when(this.agentConversationAtmssoxClient.getAgentConversation(conversationId)).thenReturn(details);
+
+        //when
+        final AgentProject actualProject = this.agentClient.getAgentProject(projectId);
+        final AgentConversationDetails actualDetails = this.agentClient.getAgentConversation(conversationId);
+
+        //then
+        assertThat(actualProject).isEqualTo(project);
+        assertThat(actualDetails).isEqualTo(details);
+        verify(this.agentProjectAtmssoxClient).getAgentProject(projectId);
+        verify(this.agentConversationAtmssoxClient).getAgentConversation(conversationId);
+    }
+
+    @Test
+    void givenNoInput_whenGetAgents_thenDelegateToAgentClient() {
+        //given
+        final AgentsResponse response = mock(AgentsResponse.class);
+        when(this.agentAtmssoxClient.getAgents()).thenReturn(response);
+
+        //when
+        final AgentsResponse actual = this.agentClient.getAgents();
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentAtmssoxClient).getAgents();
+    }
+
+    @Test
+    void givenAgentId_whenGetActivateArchiveRestoreDelete_thenDelegateToAgentClient() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final Agent response = mock(Agent.class);
+        when(this.agentAtmssoxClient.getAgent(agentId)).thenReturn(response);
+        when(this.agentAtmssoxClient.activateAgent(agentId)).thenReturn(response);
+        when(this.agentAtmssoxClient.archiveAgent(agentId)).thenReturn(response);
+        when(this.agentAtmssoxClient.restoreAgent(agentId)).thenReturn(response);
+        when(this.agentAtmssoxClient.deleteAgent(agentId)).thenReturn(response);
+
+        //when
+        this.agentClient.getAgent(agentId);
+        this.agentClient.activateAgent(agentId);
+        this.agentClient.archiveAgent(agentId);
+        this.agentClient.restoreAgent(agentId);
+        this.agentClient.deleteAgent(agentId);
+
+        //then
+        verify(this.agentAtmssoxClient).getAgent(agentId);
+        verify(this.agentAtmssoxClient).activateAgent(agentId);
+        verify(this.agentAtmssoxClient).archiveAgent(agentId);
+        verify(this.agentAtmssoxClient).restoreAgent(agentId);
+        verify(this.agentAtmssoxClient).deleteAgent(agentId);
+    }
+
+    @Test
+    void givenConversationAgentId_whenGetConversations_thenDelegateToConversationClient() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final AgentConversationsResponse response = mock(AgentConversationsResponse.class);
+        when(this.agentConversationAtmssoxClient.getAgentConversations(agentId)).thenReturn(response);
+
+        //when
+        final AgentConversationsResponse actual = this.agentClient.getAgentConversations(agentId);
+
+        //then
+        assertThat(actual).isEqualTo(response);
+        verify(this.agentConversationAtmssoxClient).getAgentConversations(agentId);
+    }
+
+    @Test
+    void givenRuleRequests_whenMutateRules_thenDelegateToRuleClient() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final com.sitionix.bffssox.domain.CreateAgentRuleRequest createRequest = mock(com.sitionix.bffssox.domain.CreateAgentRuleRequest.class);
+        final PatchAgentRuleRequest patchRequest = mock(PatchAgentRuleRequest.class);
+        final com.sitionix.bffssox.domain.AcceptAgentRuleRequest acceptRequest = mock(com.sitionix.bffssox.domain.AcceptAgentRuleRequest.class);
+        final AgentRule rule = mock(AgentRule.class);
+        final DeleteAgentRuleResponse deleteResponse = mock(DeleteAgentRuleResponse.class);
+        when(this.agentRuleAtmssoxClient.createAgentRule(agentId, createRequest)).thenReturn(rule);
+        when(this.agentRuleAtmssoxClient.patchAgentRule(agentId, ruleId, patchRequest)).thenReturn(rule);
+        when(this.agentRuleAtmssoxClient.acceptAgentRule(agentId, ruleId, acceptRequest)).thenReturn(rule);
+        when(this.agentRuleAtmssoxClient.rejectAgentRule(agentId, ruleId)).thenReturn(rule);
+        when(this.agentRuleAtmssoxClient.deleteAgentRule(agentId, ruleId)).thenReturn(deleteResponse);
+
+        //when
+        this.agentClient.createAgentRule(agentId, createRequest);
+        this.agentClient.patchAgentRule(agentId, ruleId, patchRequest);
+        this.agentClient.acceptAgentRule(agentId, ruleId, acceptRequest);
+        this.agentClient.rejectAgentRule(agentId, ruleId);
+        this.agentClient.deleteAgentRule(agentId, ruleId);
+
+        //then
+        verify(this.agentRuleAtmssoxClient).createAgentRule(agentId, createRequest);
+        verify(this.agentRuleAtmssoxClient).patchAgentRule(agentId, ruleId, patchRequest);
+        verify(this.agentRuleAtmssoxClient).acceptAgentRule(agentId, ruleId, acceptRequest);
+        verify(this.agentRuleAtmssoxClient).rejectAgentRule(agentId, ruleId);
+        verify(this.agentRuleAtmssoxClient).deleteAgentRule(agentId, ruleId);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentConversationAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentConversationAtmssoxClientTest.java
@@ -1,7 +1,9 @@
 package com.sitionix.bffssox.client;
 
 import com.app_afesox.atmssox.client.api.AgentConversationApi;
+import com.app_afesox.atmssox.client.dto.AgentConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
+import com.sitionix.bffssox.domain.AgentConversationDetails;
 import com.sitionix.bffssox.domain.AgentConversationsResponse;
 import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
 import java.util.UUID;
@@ -64,5 +66,39 @@ class AgentConversationAtmssoxClientTest {
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentConversationApi).getAgentConversations(agentId);
         verify(this.chatAgentClientMapper).asAgentConversationsResponse(responseDTO);
+    }
+
+    @Test
+    void givenConversationId_whenGetAgentConversation_thenReturnMappedDetails() {
+        //given
+        final UUID conversationId = UUID.randomUUID();
+        final AgentConversationDetailsDTO responseDTO = mock(AgentConversationDetailsDTO.class);
+        final AgentConversationDetails expected = mock(AgentConversationDetails.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentConversationDetailsDTO>) invocation.getArgument(0)).get());
+        when(this.agentConversationApi.getAgentConversation(conversationId)).thenReturn(responseDTO);
+        when(this.chatAgentClientMapper.asAgentConversationDetails(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentConversationDetails actual = this.agentConversationAtmssoxClient.getAgentConversation(conversationId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentConversationApi).getAgentConversation(conversationId);
+        verify(this.chatAgentClientMapper).asAgentConversationDetails(responseDTO);
+    }
+
+    @Test
+    void givenConversationId_whenDeleteAgentConversation_thenDelegateToApi() {
+        //given
+        final UUID conversationId = UUID.randomUUID();
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<Object>) invocation.getArgument(0)).get());
+
+        //when
+        this.agentConversationAtmssoxClient.deleteAgentConversation(conversationId);
+
+        //then
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentConversationApi).deleteAgentConversation(conversationId);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentConversationAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentConversationAtmssoxClientTest.java
@@ -1,0 +1,68 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentConversationApi;
+import com.app_afesox.atmssox.client.dto.AgentConversationsResponseDTO;
+import com.sitionix.bffssox.domain.AgentConversationsResponse;
+import com.sitionix.bffssox.mapper.ChatAgentClientMapper;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentConversationAtmssoxClientTest {
+
+    private AgentConversationAtmssoxClient agentConversationAtmssoxClient;
+
+    @Mock
+    private AgentConversationApi agentConversationApi;
+    @Mock
+    private ChatAgentClientMapper chatAgentClientMapper;
+    @Mock
+    private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    @BeforeEach
+    void setUp() {
+        this.agentConversationAtmssoxClient = new AgentConversationAtmssoxClient(
+                this.agentConversationApi,
+                this.chatAgentClientMapper,
+                this.atmssoxClientCallExecutor
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentConversationApi, this.chatAgentClientMapper, this.atmssoxClientCallExecutor);
+    }
+
+    @Test
+    void givenAgentId_whenGetAgentConversations_thenReturnMappedResponse() {
+        //given
+        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final AgentConversationsResponseDTO responseDTO = mock(AgentConversationsResponseDTO.class);
+        final AgentConversationsResponse expected = mock(AgentConversationsResponse.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentConversationsResponseDTO>) invocation.getArgument(0)).get());
+        when(this.agentConversationApi.getAgentConversations(agentId)).thenReturn(responseDTO);
+        when(this.chatAgentClientMapper.asAgentConversationsResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentConversationsResponse actual = this.agentConversationAtmssoxClient.getAgentConversations(agentId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentConversationApi).getAgentConversations(agentId);
+        verify(this.chatAgentClientMapper).asAgentConversationsResponse(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClientTest.java
@@ -1,0 +1,76 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentProjectApi;
+import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
+import com.app_afesox.atmssox.client.dto.CreateAgentProjectRequestDTO;
+import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
+import com.sitionix.bffssox.mapper.AgentClientMapper;
+import com.sitionix.bffssox.mapper.CreateAgentProjectClientMapper;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentProjectAtmssoxClientTest {
+
+    private AgentProjectAtmssoxClient agentProjectAtmssoxClient;
+
+    @Mock
+    private AgentProjectApi agentProjectApi;
+    @Mock
+    private CreateAgentProjectClientMapper createAgentProjectClientMapper;
+    @Mock
+    private AgentClientMapper agentClientMapper;
+    @Mock
+    private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    @BeforeEach
+    void setUp() {
+        this.agentProjectAtmssoxClient = new AgentProjectAtmssoxClient(
+                this.agentProjectApi,
+                this.createAgentProjectClientMapper,
+                this.agentClientMapper,
+                this.atmssoxClientCallExecutor
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentProjectApi, this.createAgentProjectClientMapper, this.agentClientMapper, this.atmssoxClientCallExecutor);
+    }
+
+    @Test
+    void givenCreateProjectRequest_whenCreateAgentProject_thenReturnMappedProject() {
+        //given
+        final CreateAgentProjectRequest request = mock(CreateAgentProjectRequest.class);
+        final CreateAgentProjectRequestDTO requestDTO = mock(CreateAgentProjectRequestDTO.class);
+        final AgentProjectDTO responseDTO = mock(AgentProjectDTO.class);
+        final AgentProject expected = mock(AgentProject.class);
+        when(this.createAgentProjectClientMapper.asCreateAgentProjectRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentProjectDTO>) invocation.getArgument(0)).get());
+        when(this.agentProjectApi.createAgentProject(requestDTO)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgentProject(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentProject actual = this.agentProjectAtmssoxClient.createAgentProject(request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.createAgentProjectClientMapper).asCreateAgentProjectRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentProjectApi).createAgentProject(requestDTO);
+        verify(this.agentClientMapper).asAgentProject(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentRuleAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentRuleAtmssoxClientTest.java
@@ -1,0 +1,70 @@
+package com.sitionix.bffssox.client;
+
+import com.app_afesox.atmssox.client.api.AgentRuleApi;
+import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
+import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AgentRule;
+import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
+import com.sitionix.bffssox.mapper.AgentRuleClientMapper;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentRuleAtmssoxClientTest {
+
+    private AgentRuleAtmssoxClient agentRuleAtmssoxClient;
+
+    @Mock
+    private AgentRuleApi agentRuleApi;
+    @Mock
+    private AgentRuleClientMapper agentRuleClientMapper;
+    @Mock
+    private AtmssoxClientCallExecutor atmssoxClientCallExecutor;
+
+    @BeforeEach
+    void setUp() {
+        this.agentRuleAtmssoxClient = new AgentRuleAtmssoxClient(this.agentRuleApi, this.agentRuleClientMapper, this.atmssoxClientCallExecutor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(this.agentRuleApi, this.agentRuleClientMapper, this.atmssoxClientCallExecutor);
+    }
+
+    @Test
+    void givenCreateRuleRequest_whenCreateAgentRule_thenReturnMappedRule() {
+        //given
+        final UUID agentId = UUID.fromString("3064ed14-b2ab-4c37-a264-94574beb8dd2");
+        final CreateAgentRuleRequest request = mock(CreateAgentRuleRequest.class);
+        final CreateAgentRuleRequestDTO requestDTO = mock(CreateAgentRuleRequestDTO.class);
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+        when(this.agentRuleClientMapper.asCreateAgentRuleRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentRuleDTO>) invocation.getArgument(0)).get());
+        when(this.agentRuleApi.createAgentRule(agentId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentRuleAtmssoxClient.createAgentRule(agentId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentRuleClientMapper).asCreateAgentRuleRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentRuleApi).createAgentRule(agentId, requestDTO);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+}

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentRuleAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentRuleAtmssoxClientTest.java
@@ -1,10 +1,19 @@
 package com.sitionix.bffssox.client;
 
 import com.app_afesox.atmssox.client.api.AgentRuleApi;
+import com.app_afesox.atmssox.client.dto.AcceptAgentRuleRequestDTO;
+import com.app_afesox.atmssox.client.dto.AgentRulesResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentRuleDTO;
+import com.app_afesox.atmssox.client.dto.DeleteAgentRuleResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentRuleRequestDTO;
+import com.app_afesox.atmssox.client.dto.PatchAgentRuleRequestDTO;
+import com.sitionix.bffssox.domain.AcceptAgentRuleRequest;
 import com.sitionix.bffssox.domain.AgentRule;
+import com.sitionix.bffssox.domain.AgentRulesResponse;
 import com.sitionix.bffssox.domain.CreateAgentRuleRequest;
+import com.sitionix.bffssox.domain.DeleteAgentRuleResponse;
+import com.sitionix.bffssox.domain.GetAgentRulesQuery;
+import com.sitionix.bffssox.domain.PatchAgentRuleRequest;
 import com.sitionix.bffssox.mapper.AgentRuleClientMapper;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -66,5 +75,120 @@ class AgentRuleAtmssoxClientTest {
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentRuleApi).createAgentRule(agentId, requestDTO);
         verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenAgentAndQuery_whenGetAgentRules_thenReturnMappedResponse() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final GetAgentRulesQuery query = new GetAgentRulesQuery("ACTIVE", "USER");
+        final AgentRulesResponseDTO responseDTO = mock(AgentRulesResponseDTO.class);
+        final AgentRulesResponse expected = mock(AgentRulesResponse.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentRulesResponseDTO>) invocation.getArgument(0)).get());
+        when(this.agentRuleApi.getAgentRules(agentId, com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO.ACTIVE,
+                com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO.USER)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRulesResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRulesResponse actual = this.agentRuleAtmssoxClient.getAgentRules(agentId, query);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentRuleApi).getAgentRules(agentId, com.app_afesox.atmssox.client.dto.AgentRuleStatusDTO.ACTIVE,
+                com.app_afesox.atmssox.client.dto.AgentRuleAuthorTypeDTO.USER);
+        verify(this.agentRuleClientMapper).asAgentRulesResponse(responseDTO);
+    }
+
+    @Test
+    void givenPatchRequest_whenPatchAgentRule_thenReturnMappedRule() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final PatchAgentRuleRequest request = mock(PatchAgentRuleRequest.class);
+        final PatchAgentRuleRequestDTO requestDTO = mock(PatchAgentRuleRequestDTO.class);
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+        when(this.agentRuleClientMapper.asPatchAgentRuleRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentRuleDTO>) invocation.getArgument(0)).get());
+        when(this.agentRuleApi.patchAgentRule(agentId, ruleId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentRuleAtmssoxClient.patchAgentRule(agentId, ruleId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentRuleClientMapper).asPatchAgentRuleRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentRuleApi).patchAgentRule(agentId, ruleId, requestDTO);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenAcceptRequest_whenAcceptAgentRule_thenReturnMappedRule() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final AcceptAgentRuleRequest request = mock(AcceptAgentRuleRequest.class);
+        final AcceptAgentRuleRequestDTO requestDTO = mock(AcceptAgentRuleRequestDTO.class);
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+        when(this.agentRuleClientMapper.asAcceptAgentRuleRequestDto(request)).thenReturn(requestDTO);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentRuleDTO>) invocation.getArgument(0)).get());
+        when(this.agentRuleApi.acceptAgentRule(agentId, ruleId, requestDTO)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentRuleAtmssoxClient.acceptAgentRule(agentId, ruleId, request);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.agentRuleClientMapper).asAcceptAgentRuleRequestDto(request);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentRuleApi).acceptAgentRule(agentId, ruleId, requestDTO);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenRuleId_whenRejectAgentRule_thenReturnMappedRule() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final AgentRuleDTO responseDTO = mock(AgentRuleDTO.class);
+        final AgentRule expected = mock(AgentRule.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentRuleDTO>) invocation.getArgument(0)).get());
+        when(this.agentRuleApi.rejectAgentRule(agentId, ruleId)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asAgentRule(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentRule actual = this.agentRuleAtmssoxClient.rejectAgentRule(agentId, ruleId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentRuleApi).rejectAgentRule(agentId, ruleId);
+        verify(this.agentRuleClientMapper).asAgentRule(responseDTO);
+    }
+
+    @Test
+    void givenRuleId_whenDeleteAgentRule_thenReturnMappedResponse() {
+        //given
+        final UUID agentId = UUID.randomUUID();
+        final UUID ruleId = UUID.randomUUID();
+        final DeleteAgentRuleResponseDTO responseDTO = mock(DeleteAgentRuleResponseDTO.class);
+        final DeleteAgentRuleResponse expected = mock(DeleteAgentRuleResponse.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<DeleteAgentRuleResponseDTO>) invocation.getArgument(0)).get());
+        when(this.agentRuleApi.deleteAgentRule(agentId, ruleId)).thenReturn(responseDTO);
+        when(this.agentRuleClientMapper.asDeleteAgentRuleResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final DeleteAgentRuleResponse actual = this.agentRuleAtmssoxClient.deleteAgentRule(agentId, ruleId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentRuleApi).deleteAgentRule(agentId, ruleId);
+        verify(this.agentRuleClientMapper).asDeleteAgentRuleResponse(responseDTO);
     }
 }


### PR DESCRIPTION
## Summary\n- split overloaded agent controller into tag-aligned controllers\n- align ATMS client integration with split generated APIs\n- move/update controller unit tests\n\n## Validation\n- mvn -q -f pom.xml -pl api-rest,clients/client-atmssox,boot test