### PR TITLE
[SITIONIX-139] - BFF conversation submit mapping cleanup

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.41</bffssox.api.version>
+        <bffssox.api.version>0.0.42</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-139-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-sitionix-139-unstable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -7,6 +7,7 @@ import com.app_afesox.bffssox.api_first.dto.AgentConversationsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatExecutionDTO;
 import com.app_afesox.bffssox.api_first.dto.ChatAgentResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.ExecutionStatusDTO;
 import com.app_afesox.bffssox.api_first.dto.SubmitConversationExecutionRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.SubmitConversationExecutionResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateProjectConversationRequestDTO;
@@ -23,6 +24,7 @@ import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.ChatAgentMessage;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
+import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.SubmitConversationExecutionResponse;
 import com.sitionix.bffssox.domain.CreateProjectConversationRequest;
 import com.sitionix.bffssox.domain.ProjectConversation;
@@ -57,7 +59,9 @@ public interface ChatAgentApiMapper {
     @Mapping(target = "error", ignore = true)
     SubmitChatExecutionResponseDTO asSubmitChatExecutionResponseDto(SubmitChatExecutionResponse src);
 
-    @Mapping(target = "executionStatus", source = "executionStatus")
+    @Mapping(target = "executionId", expression = "java(Boolean.TRUE.equals(src.getRuntimeDispatched()) ? src.getExecutionId() : null)")
+    @Mapping(target = "executionStatus",
+            expression = "java(mapSubmitExecutionStatus(src.getExecutionStatus(), src.getRuntimeDispatched()))")
     SubmitConversationExecutionResponseDTO asSubmitConversationExecutionResponseDto(SubmitConversationExecutionResponse src);
 
     @Mapping(target = "status", source = "state")
@@ -77,7 +81,7 @@ public interface ChatAgentApiMapper {
     AgentConversationsResponseDTO asAgentConversationsResponseDto(AgentConversationsResponse src);
 
     @Mapping(target = "messages", source = "messages")
-    @Mapping(target = "executions", source = "executions")
+    @Mapping(target = "execution", source = "executions")
     AgentConversationDetailsDTO asAgentConversationDetailsDto(AgentConversationDetails src);
 
     default AgentConversationDetailsDTO.TypeEnum map(final String value) {
@@ -128,6 +132,27 @@ public interface ChatAgentApiMapper {
 
     default ProjectConversationParticipantDTO.StatusEnum mapProjectConversationParticipantStatus(final String value) {
         return value == null ? null : ProjectConversationParticipantDTO.StatusEnum.fromValue(value);
+    }
+
+    default ChatExecutionDTO mapExecution(final List<ChatExecution> executions) {
+        if (executions == null || executions.isEmpty()) {
+            return null;
+        }
+        return this.asChatExecutionDto(executions.get(0));
+    }
+
+    default ExecutionStatusDTO mapSubmitExecutionStatus(final String value, final Boolean runtimeDispatched) {
+        if (!Boolean.TRUE.equals(runtimeDispatched)) {
+            return null;
+        }
+        if (value == null) {
+            return null;
+        }
+        return switch (value) {
+            case "QUEUED" -> ExecutionStatusDTO.ACCEPTED;
+            case "COMPLETED" -> ExecutionStatusDTO.SUCCEEDED;
+            default -> ExecutionStatusDTO.fromValue(value);
+        };
     }
 
 }

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -24,7 +24,6 @@ import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.ChatAgentMessage;
 import com.sitionix.bffssox.domain.ChatAgentRequest;
 import com.sitionix.bffssox.domain.ChatAgentResponse;
-import com.sitionix.bffssox.domain.ChatExecution;
 import com.sitionix.bffssox.domain.SubmitConversationExecutionResponse;
 import com.sitionix.bffssox.domain.CreateProjectConversationRequest;
 import com.sitionix.bffssox.domain.ProjectConversation;

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -35,6 +35,7 @@ import com.sitionix.bffssox.domain.ProjectConversationsResponse;
 import com.sitionix.bffssox.domain.SubmitConversationExecutionResponse;
 import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -309,6 +310,56 @@ class ChatAgentApiMapperTest {
         assertThat(actual.getInputMessageId()).isEqualTo(given.getInputMessageId());
         assertThat(actual.getExecutionId()).isNull();
         assertThat(actual.getExecutionStatus()).isNull();
+    }
+
+    @Test
+    void givenRuntimeDispatchedNull_whenMapSubmitExecutionStatus_thenReturnNull() {
+        //given
+        final String executionStatus = "QUEUED";
+        final Boolean runtimeDispatched = null;
+
+        //when
+        final ExecutionStatusDTO actual = this.mapper.mapSubmitExecutionStatus(executionStatus, runtimeDispatched);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenCompletedExecutionStatusAndRuntimeDispatchedTrue_whenMapSubmitExecutionStatus_thenReturnSucceeded() {
+        //given
+        final String executionStatus = "COMPLETED";
+        final Boolean runtimeDispatched = Boolean.TRUE;
+
+        //when
+        final ExecutionStatusDTO actual = this.mapper.mapSubmitExecutionStatus(executionStatus, runtimeDispatched);
+
+        //then
+        assertThat(actual).isEqualTo(ExecutionStatusDTO.SUCCEEDED);
+    }
+
+    @Test
+    void givenNullExecutions_whenMapExecution_thenReturnNull() {
+        //given
+        final List<ChatExecution> executions = null;
+
+        //when
+        final ChatExecutionDTO actual = this.mapper.mapExecution(executions);
+
+        //then
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void givenEmptyExecutions_whenMapExecution_thenReturnNull() {
+        //given
+        final List<ChatExecution> executions = Collections.emptyList();
+
+        //when
+        final ChatExecutionDTO actual = this.mapper.mapExecution(executions);
+
+        //then
+        assertThat(actual).isNull();
     }
 
     @Test

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -16,6 +16,7 @@ import com.app_afesox.bffssox.api_first.dto.ProjectConversationDetailsDTO;
 import com.app_afesox.bffssox.api_first.dto.ProjectConversationParticipantDTO;
 import com.app_afesox.bffssox.api_first.dto.ProjectConversationProjectDTO;
 import com.app_afesox.bffssox.api_first.dto.ProjectConversationsResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.SubmitConversationExecutionResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.SubmitChatExecutionResponseDTO;
 import com.sitionix.bffssox.domain.AgentConversation;
 import com.sitionix.bffssox.domain.AgentConversationDetails;
@@ -31,6 +32,7 @@ import com.sitionix.bffssox.domain.ProjectConversationDetails;
 import com.sitionix.bffssox.domain.ProjectConversationParticipant;
 import com.sitionix.bffssox.domain.ProjectConversationProject;
 import com.sitionix.bffssox.domain.ProjectConversationsResponse;
+import com.sitionix.bffssox.domain.SubmitConversationExecutionResponse;
 import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -280,6 +282,36 @@ class ChatAgentApiMapperTest {
     }
 
     @Test
+    void givenSubmitConversationExecutionResponseWithRuntimeDispatch_whenAsSubmitConversationExecutionResponseDto_thenReturnExecutionMetadata() {
+        //given
+        final SubmitConversationExecutionResponse given = this.getSubmitConversationExecutionResponse(Boolean.TRUE, "QUEUED");
+
+        //when
+        final SubmitConversationExecutionResponseDTO actual = this.mapper.asSubmitConversationExecutionResponseDto(given);
+
+        //then
+        assertThat(actual.getConversationId()).isEqualTo(given.getConversationId());
+        assertThat(actual.getInputMessageId()).isEqualTo(given.getInputMessageId());
+        assertThat(actual.getExecutionId()).isEqualTo(given.getExecutionId());
+        assertThat(actual.getExecutionStatus()).isEqualTo(ExecutionStatusDTO.ACCEPTED);
+    }
+
+    @Test
+    void givenSubmitConversationExecutionResponseWithoutRuntimeDispatch_whenAsSubmitConversationExecutionResponseDto_thenReturnNullExecutionMetadata() {
+        //given
+        final SubmitConversationExecutionResponse given = this.getSubmitConversationExecutionResponse(Boolean.FALSE, "QUEUED");
+
+        //when
+        final SubmitConversationExecutionResponseDTO actual = this.mapper.asSubmitConversationExecutionResponseDto(given);
+
+        //then
+        assertThat(actual.getConversationId()).isEqualTo(given.getConversationId());
+        assertThat(actual.getInputMessageId()).isEqualTo(given.getInputMessageId());
+        assertThat(actual.getExecutionId()).isNull();
+        assertThat(actual.getExecutionStatus()).isNull();
+    }
+
+    @Test
     void givenNullProjectConversationEnums_whenMapProjectConversationEnums_thenReturnNulls() {
         //given
         final String nullValue = null;
@@ -522,6 +554,19 @@ class ChatAgentApiMapperTest {
                 .createdAt(OffsetDateTime.parse("2026-04-29T10:00:00Z"))
                 .idempotencyKey("idem")
                 .idempotencyReplayed(false)
+                .build();
+    }
+
+    private SubmitConversationExecutionResponse getSubmitConversationExecutionResponse(
+            final Boolean runtimeDispatched,
+            final String executionStatus
+    ) {
+        return SubmitConversationExecutionResponse.builder()
+                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
+                .inputMessageId(UUID.fromString("f0beec7e-5c98-48b9-ae82-0a6952576a7a"))
+                .runtimeDispatched(runtimeDispatched)
+                .executionStatus(executionStatus)
                 .build();
     }
 

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -190,7 +190,7 @@ class ChatAgentApiMapperTest {
                         "Clean architecture separates business logic.",
                         createdAt
                 )),
-                List.of(this.mapper.asChatExecutionDto(this.getFailedChatExecution()))
+                this.mapper.asChatExecutionDto(this.getFailedChatExecution())
         );
 
         //when
@@ -467,7 +467,7 @@ class ChatAgentApiMapperTest {
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
             final List<AgentConversationMessageDTO> messages,
-            final List<ChatExecutionDTO> executions
+            final ChatExecutionDTO execution
     ) {
         return AgentConversationDetailsDTO.builder()
                 .id(id)
@@ -477,7 +477,7 @@ class ChatAgentApiMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
-                .executions(executions)
+                .execution(execution)
                 .build();
     }
 

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentConversationControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentConversationControllerIT.java
@@ -482,14 +482,14 @@ class AgentConversationControllerIT {
     }
 
     @Test
-    @DisplayName("given upstream dispatch skipped status when submit conversation execution then return unchanged status")
-    void givenUpstreamDispatchSkippedStatus_whenSubmitConversationExecution_thenReturnUnchangedStatus() {
+    @DisplayName("given upstream runtime dispatch disabled when submit conversation execution then return null execution metadata")
+    void givenUpstreamRuntimeDispatchDisabled_whenSubmitConversationExecution_thenReturnNullExecutionMetadata() {
         //given
         final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
                 .createMapping(WireMockEndpoint.POST_CONVERSATION_EXECUTION)
                 .pathPattern(WireMockPathParams.create()
                         .add("conversationId", "11111111-1111-1111-1111-111111111111"))
-                .applyDefault(context -> context.responseBody("responseDefaultMappingSubmitConversationExecutionDispatchSkipped.json"))
+                .applyDefault(context -> context.responseBody("responseDefaultMappingSubmitConversationExecutionRuntimeNotDispatched.json"))
                 .createDefault();
 
         //when then
@@ -497,7 +497,7 @@ class AgentConversationControllerIT {
                 .ping(MockMvcEndpoint.POST_CONVERSATION_EXECUTION)
                 .withPathParameters(PathParams.create()
                         .add("conversationId", "11111111-1111-1111-1111-111111111111"))
-                .applyDefault(context -> context.expectResponse("responseDefaultSubmitConversationExecutionDispatchSkipped.json"))
+                .applyDefault(context -> context.expectResponse("responseDefaultSubmitConversationExecutionRuntimeNotDispatched.json"))
                 .assertDefault();
 
         requestBuilder.verify();

--- a/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentConversationControllerIT.java
+++ b/boot/src/test/java/com/sitionix/bffssox/it/tests/AgentConversationControllerIT.java
@@ -227,6 +227,28 @@ class AgentConversationControllerIT {
     }
 
     @Test
+    @DisplayName("given upstream execution metadata when get one agent conversation then return execution object")
+    void givenUpstreamExecutionMetadata_whenGetOneAgentConversation_thenReturnExecutionObject() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.GET_AGENT_CONVERSATION)
+                .pathPattern(WireMockPathParams.create()
+                        .add("conversationId", "11111111-1111-1111-1111-111111111111"))
+                .responseBody("responseDefaultMappingGetAgentConversationWithExecutionInProgress.json")
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.GET_AGENT_CONVERSATION)
+                .withPathParameters(PathParams.create()
+                        .add("conversationId", "11111111-1111-1111-1111-111111111111"))
+                .applyDefault(context -> context.expectResponse("responseDefaultGetAgentConversationWithExecutionInProgress.json"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
     @DisplayName("given invalid conversation id when get one agent conversation then return bad request")
     void givenInvalidConversationId_whenGetOneAgentConversation_thenReturnBadRequest() {
         //given
@@ -498,6 +520,28 @@ class AgentConversationControllerIT {
                 .withPathParameters(PathParams.create()
                         .add("conversationId", "11111111-1111-1111-1111-111111111111"))
                 .applyDefault(context -> context.expectResponse("responseDefaultSubmitConversationExecutionRuntimeNotDispatched.json"))
+                .assertDefault();
+
+        requestBuilder.verify();
+    }
+
+    @Test
+    @DisplayName("given upstream in progress status when submit conversation execution then return in progress mapping")
+    void givenUpstreamInProgressStatus_whenSubmitConversationExecution_thenReturnInProgressMapping() {
+        //given
+        final RequestBuilder<?, ?> requestBuilder = this.testManager.wiremock()
+                .createMapping(WireMockEndpoint.POST_CONVERSATION_EXECUTION)
+                .pathPattern(WireMockPathParams.create()
+                        .add("conversationId", "11111111-1111-1111-1111-111111111111"))
+                .applyDefault(context -> context.responseBody("responseDefaultMappingSubmitConversationExecutionInProgress.json"))
+                .createDefault();
+
+        //when then
+        this.testManager.mockMvc()
+                .ping(MockMvcEndpoint.POST_CONVERSATION_EXECUTION)
+                .withPathParameters(PathParams.create()
+                        .add("conversationId", "11111111-1111-1111-1111-111111111111"))
+                .applyDefault(context -> context.expectResponse("responseDefaultSubmitConversationExecutionInProgress.json"))
                 .assertDefault();
 
         requestBuilder.verify();

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultGetAgentConversationWithExecutionInProgress.json
@@ -1,0 +1,34 @@
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "title": "Explain clean architecture",
+  "type": "DIRECT",
+  "createdAt": "2026-04-21T10:00:00Z",
+  "updatedAt": "2026-04-21T10:01:00Z",
+  "lastMessageAt": "2026-04-21T10:01:00Z",
+  "messages": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "authorType": "USER",
+      "authorId": "it-user-123",
+      "content": "Explain clean architecture",
+      "createdAt": "2026-04-21T10:00:00Z"
+    },
+    {
+      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      "authorType": "AGENT",
+      "authorId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "content": "Clean architecture separates business rules from infrastructure.",
+      "createdAt": "2026-04-21T10:01:00Z"
+    }
+  ],
+  "execution": {
+    "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+    "conversationId": "11111111-1111-1111-1111-111111111111",
+    "status": "IN_PROGRESS",
+    "acceptedAt": "2026-04-21T10:01:05Z",
+    "startedAt": "2026-04-21T10:01:06Z",
+    "completedAt": null,
+    "error": null,
+    "assistantMessage": null
+  }
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecution.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecution.json
@@ -2,5 +2,6 @@
   "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
   "conversationId": "11111111-1111-1111-1111-111111111111",
   "inputMessageId": "22222222-2222-2222-2222-222222222222",
+  "runtimeDispatched": true,
   "executionStatus": "ACCEPTED"
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecutionInProgress.json
@@ -1,0 +1,7 @@
+{
+  "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+  "conversationId": "11111111-1111-1111-1111-111111111111",
+  "inputMessageId": "22222222-2222-2222-2222-222222222222",
+  "runtimeDispatched": true,
+  "executionStatus": "IN_PROGRESS"
+}

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecutionNullableExecutionId.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecutionNullableExecutionId.json
@@ -2,5 +2,6 @@
   "executionId": null,
   "conversationId": "11111111-1111-1111-1111-111111111111",
   "inputMessageId": "22222222-2222-2222-2222-222222222222",
-  "executionStatus": "ACCEPTED"
+  "runtimeDispatched": false,
+  "executionStatus": null
 }

--- a/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecutionRuntimeNotDispatched.json
+++ b/boot/src/test/resources/forge-it/mockmvc/default/response/responseDefaultSubmitConversationExecutionRuntimeNotDispatched.json
@@ -1,6 +1,7 @@
 {
-  "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+  "executionId": null,
   "conversationId": "11111111-1111-1111-1111-111111111111",
   "inputMessageId": "22222222-2222-2222-2222-222222222222",
-  "executionStatus": "DISPATCH_SKIPPED"
+  "runtimeDispatched": false,
+  "executionStatus": null
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
@@ -1,0 +1,37 @@
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "title": "Explain clean architecture",
+  "type": "DIRECT",
+  "createdAt": "2026-04-21T10:00:00Z",
+  "updatedAt": "2026-04-21T10:01:00Z",
+  "lastMessageAt": "2026-04-21T10:01:00Z",
+  "messages": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "authorType": "USER",
+      "authorId": "it-user-123",
+      "content": "Explain clean architecture",
+      "createdAt": "2026-04-21T10:00:00Z"
+    },
+    {
+      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      "authorType": "AGENT",
+      "authorId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "content": "Clean architecture separates business rules from infrastructure.",
+      "createdAt": "2026-04-21T10:01:00Z"
+    }
+  ],
+  "executions": [
+    {
+      "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+      "conversationId": "11111111-1111-1111-1111-111111111111",
+      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "status": "IN_PROGRESS",
+      "acceptedAt": "2026-04-21T10:01:05Z",
+      "startedAt": "2026-04-21T10:01:06Z",
+      "completedAt": null,
+      "error": null,
+      "assistantMessage": null
+    }
+  ]
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecution.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecution.json
@@ -2,5 +2,6 @@
   "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
   "conversationId": "11111111-1111-1111-1111-111111111111",
   "inputMessageId": "22222222-2222-2222-2222-222222222222",
+  "runtimeDispatched": true,
   "executionStatus": "ACCEPTED"
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecutionInProgress.json
@@ -1,0 +1,7 @@
+{
+  "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+  "conversationId": "11111111-1111-1111-1111-111111111111",
+  "inputMessageId": "22222222-2222-2222-2222-222222222222",
+  "runtimeDispatched": true,
+  "executionStatus": "IN_PROGRESS"
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecutionNullableExecutionId.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecutionNullableExecutionId.json
@@ -2,5 +2,6 @@
   "executionId": null,
   "conversationId": "11111111-1111-1111-1111-111111111111",
   "inputMessageId": "22222222-2222-2222-2222-222222222222",
-  "executionStatus": "ACCEPTED"
+  "runtimeDispatched": false,
+  "executionStatus": null
 }

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecutionRuntimeNotDispatched.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingSubmitConversationExecutionRuntimeNotDispatched.json
@@ -1,6 +1,7 @@
 {
-  "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+  "executionId": null,
   "conversationId": "11111111-1111-1111-1111-111111111111",
   "inputMessageId": "22222222-2222-2222-2222-222222222222",
-  "executionStatus": "DISPATCH_SKIPPED"
+  "runtimeDispatched": false,
+  "executionStatus": null
 }

--- a/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
@@ -1,0 +1,37 @@
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "title": "Explain clean architecture",
+  "type": "DIRECT",
+  "createdAt": "2026-04-21T10:00:00Z",
+  "updatedAt": "2026-04-21T10:01:00Z",
+  "lastMessageAt": "2026-04-21T10:01:00Z",
+  "messages": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "authorType": "USER",
+      "authorId": "it-user-123",
+      "content": "Explain clean architecture",
+      "createdAt": "2026-04-21T10:00:00Z"
+    },
+    {
+      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      "authorType": "AGENT",
+      "authorId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "content": "Clean architecture separates business rules from infrastructure.",
+      "createdAt": "2026-04-21T10:01:00Z"
+    }
+  ],
+  "executions": [
+    {
+      "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+      "conversationId": "11111111-1111-1111-1111-111111111111",
+      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+      "status": "IN_PROGRESS",
+      "acceptedAt": "2026-04-21T10:01:05Z",
+      "startedAt": "2026-04-21T10:01:06Z",
+      "completedAt": null,
+      "error": null,
+      "assistantMessage": null
+    }
+  ]
+}

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -8,6 +8,7 @@ import com.app_afesox.atmssox.client.dto.ChatAgentExecutionDTO;
 import com.app_afesox.atmssox.client.dto.ChatAgentRequestDTO;
 import com.app_afesox.atmssox.client.dto.ChatExecutionDTO;
 import com.app_afesox.atmssox.client.dto.CreateProjectConversationRequestDTO;
+import com.app_afesox.atmssox.client.dto.ExecutionStatusDTO;
 import com.app_afesox.atmssox.client.dto.ProjectConversationDTO;
 import com.app_afesox.atmssox.client.dto.ProjectConversationDetailsDTO;
 import com.app_afesox.atmssox.client.dto.ProjectConversationParticipantDTO;
@@ -32,6 +33,7 @@ import com.sitionix.bffssox.domain.ProjectConversationProject;
 import com.sitionix.bffssox.domain.ProjectConversationsResponse;
 import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.util.List;
+import java.util.UUID;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mapper;
@@ -55,6 +57,10 @@ public interface ChatAgentClientMapper {
     @Mapping(target = "inputMessageId", source = "inputMessageId")
     SubmitChatExecutionResponse asSubmitChatExecutionResponse(SubmitChatExecutionResponseDTO src);
 
+    @Mapping(target = "runtimeDispatched", expression = "java(src.getExecutionId() != null && src.getExecutionStatus() != null)")
+    @Mapping(target = "executionId", expression = "java(src.getExecutionId() != null && src.getExecutionStatus() != null ? src.getExecutionId() : null)")
+    @Mapping(target = "executionStatus",
+            expression = "java(mapSubmitExecutionStatus(src.getExecutionStatus(), src.getExecutionId()))")
     SubmitConversationExecutionResponse asSubmitConversationExecutionResponse(SubmitConversationExecutionResponseDTO src);
 
     @Mapping(target = "state", source = "status")
@@ -126,5 +132,21 @@ public interface ChatAgentClientMapper {
 
     default String mapProjectConversationParticipantStatus(final ProjectConversationParticipantDTO.StatusEnum value) {
         return value == null ? null : value.getValue();
+    }
+
+    default String mapSubmitExecutionStatus(final ExecutionStatusDTO value, final UUID executionId) {
+        if (executionId == null) {
+            return null;
+        }
+        if (value == null) {
+            return null;
+        }
+        return switch (value.getValue()) {
+            case "ACCEPTED" -> "QUEUED";
+            case "IN_PROGRESS" -> "IN_PROGRESS";
+            case "SUCCEEDED" -> "COMPLETED";
+            case "FAILED" -> "FAILED";
+            default -> value.getValue();
+        };
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -249,6 +250,34 @@ class ChatAgentClientMapperTest {
 
         //then
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void givenSubmitConversationExecutionResponseDtoWithoutExecutionMetadata_whenAsSubmitConversationExecutionResponse_thenReturnRuntimeDispatchedFalse() {
+        //given
+        final SubmitConversationExecutionResponseDTO given = this.getSubmitConversationExecutionResponseDto(null, null);
+
+        //when
+        final SubmitConversationExecutionResponse actual = this.mapper.asSubmitConversationExecutionResponse(given);
+
+        //then
+        assertThat(actual.getConversationId()).isEqualTo(given.getConversationId());
+        assertThat(actual.getInputMessageId()).isEqualTo(given.getInputMessageId());
+        assertThat(actual.getRuntimeDispatched()).isFalse();
+        assertThat(actual.getExecutionId()).isNull();
+        assertThat(actual.getExecutionStatus()).isNull();
+    }
+
+    @Test
+    void givenUnknownExecutionStatusValue_whenCreateExecutionStatusDto_thenThrowIllegalArgumentException() {
+        //given
+        final String unknownStatus = "SOME_NEW_STATUS";
+
+        //when
+        //then
+        assertThatThrownBy(() -> ExecutionStatusDTO.fromValue(unknownStatus))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unexpected value");
     }
 
     @Test
@@ -541,11 +570,21 @@ class ChatAgentClientMapperTest {
     }
 
     private SubmitConversationExecutionResponseDTO getSubmitConversationExecutionResponseDto() {
+        return this.getSubmitConversationExecutionResponseDto(
+                UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"),
+                ExecutionStatusDTO.ACCEPTED
+        );
+    }
+
+    private SubmitConversationExecutionResponseDTO getSubmitConversationExecutionResponseDto(
+            final UUID executionId,
+            final ExecutionStatusDTO executionStatus
+    ) {
         return SubmitConversationExecutionResponseDTO.builder()
-                .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
+                .executionId(executionId)
                 .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
                 .inputMessageId(UUID.fromString("f0beec7e-5c98-48b9-ae82-0a6952576a7a"))
-                .executionStatus(ExecutionStatusDTO.ACCEPTED)
+                .executionStatus(executionStatus)
                 .build();
     }
 

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -43,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -278,6 +279,56 @@ class ChatAgentClientMapperTest {
         assertThatThrownBy(() -> ExecutionStatusDTO.fromValue(unknownStatus))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unexpected value");
+    }
+
+    @Test
+    void givenExecutionIdAndStatusInProgress_whenMapSubmitExecutionStatus_thenReturnInProgress() {
+        //given
+        final UUID executionId = UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95");
+
+        //when
+        final String actual = this.mapper.mapSubmitExecutionStatus(ExecutionStatusDTO.IN_PROGRESS, executionId);
+
+        //then
+        assertThat(actual).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    void givenExecutionIdAndStatusSucceeded_whenMapSubmitExecutionStatus_thenReturnCompleted() {
+        //given
+        final UUID executionId = UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95");
+
+        //when
+        final String actual = this.mapper.mapSubmitExecutionStatus(ExecutionStatusDTO.SUCCEEDED, executionId);
+
+        //then
+        assertThat(actual).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void givenExecutionIdAndStatusFailed_whenMapSubmitExecutionStatus_thenReturnFailed() {
+        //given
+        final UUID executionId = UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95");
+
+        //when
+        final String actual = this.mapper.mapSubmitExecutionStatus(ExecutionStatusDTO.FAILED, executionId);
+
+        //then
+        assertThat(actual).isEqualTo("FAILED");
+    }
+
+    @Test
+    void givenExecutionIdAndUnknownStatus_whenMapSubmitExecutionStatus_thenReturnRawValue() {
+        //given
+        final UUID executionId = UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95");
+        final ExecutionStatusDTO executionStatus = mock(ExecutionStatusDTO.class);
+        when(executionStatus.getValue()).thenReturn("UNKNOWN_STATUS");
+
+        //when
+        final String actual = this.mapper.mapSubmitExecutionStatus(executionStatus, executionId);
+
+        //then
+        assertThat(actual).isEqualTo("UNKNOWN_STATUS");
     }
 
     @Test

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -243,7 +243,6 @@ class ChatAgentClientMapperTest {
         //given
         final SubmitConversationExecutionResponseDTO given = this.getSubmitConversationExecutionResponseDto();
         final SubmitConversationExecutionResponse expected = this.getSubmitConversationExecutionResponse();
-        when(this.chatExecutionStatusClientMapper.mapExecutionStatus(ExecutionStatusDTO.ACCEPTED)).thenReturn("QUEUED");
 
         //when
         final SubmitConversationExecutionResponse actual = this.mapper.asSubmitConversationExecutionResponse(given);
@@ -555,6 +554,7 @@ class ChatAgentClientMapperTest {
                 .executionId(UUID.fromString("d8827667-03f3-4d46-ae0d-d35e43ecdf95"))
                 .conversationId(UUID.fromString("5bddb194-5ca2-4461-9b6b-c5f986fa86ea"))
                 .inputMessageId(UUID.fromString("f0beec7e-5c98-48b9-ae82-0a6952576a7a"))
+                .runtimeDispatched(Boolean.TRUE)
                 .executionStatus("QUEUED")
                 .build();
     }

--- a/domain/src/main/java/com/sitionix/bffssox/domain/SubmitConversationExecutionResponse.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/SubmitConversationExecutionResponse.java
@@ -12,6 +12,8 @@ public class SubmitConversationExecutionResponse {
 
     private UUID inputMessageId;
 
+    private Boolean runtimeDispatched;
+
     private UUID executionId;
 
     private String executionStatus;


### PR DESCRIPTION
## Summary
- remove BFF boundary usage of DISPATCH_SKIPPED for submit conversation execution responses
- always propagate persisted message metadata and gate execution metadata to real dispatched execution only
- align integration fixtures/tests for dispatch-enabled and dispatch-disabled response paths

## Validation
- mvn clean install