### PR TITLE
[SITIONIX-140] - Expose project flow and palette read endpoints

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>api-rest</artifactId>
 
     <properties>
-        <bffssox.api.version>0.0.42</bffssox.api.version>
+        <bffssox.api.version>0.0.43</bffssox.api.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-bffssox-api-first-stable</artifactId>
+            <artifactId>app-afesox-bffssox-api-first-sitionix-140-unstable</artifactId>
             <version>${bffssox.api.version}</version>
         </dependency>
         <dependency>

--- a/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentProjectController.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/controller/AgentProjectController.java
@@ -3,6 +3,8 @@ package com.sitionix.bffssox.controller;
 import com.app_afesox.bffssox.api_first.api.AgentProjectApi;
 import com.app_afesox.bffssox.api_first.dto.AddAgentToProjectRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowPaletteResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.PatchAgentProjectRequestDTO;
@@ -10,6 +12,8 @@ import com.app_afesox.bffssox.api_first.dto.ProjectAgentResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ProjectAgentsResponseDTO;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
 import com.sitionix.bffssox.domain.ProjectAgent;
@@ -21,6 +25,8 @@ import com.sitionix.bffssox.usecase.AddAgentToProject;
 import com.sitionix.bffssox.usecase.CreateAgentProject;
 import com.sitionix.bffssox.usecase.DeleteAgentProject;
 import com.sitionix.bffssox.usecase.GetAgentProject;
+import com.sitionix.bffssox.usecase.GetAgentProjectFlow;
+import com.sitionix.bffssox.usecase.GetAgentProjectFlowPalette;
 import com.sitionix.bffssox.usecase.GetAgentProjects;
 import com.sitionix.bffssox.usecase.GetProjectAgents;
 import com.sitionix.bffssox.usecase.PatchAgentProject;
@@ -42,6 +48,8 @@ public class AgentProjectController implements AgentProjectApi {
     private final CreateAgentProject createAgentProject;
     private final GetAgentProjects getAgentProjects;
     private final GetAgentProject getAgentProject;
+    private final GetAgentProjectFlow getAgentProjectFlow;
+    private final GetAgentProjectFlowPalette getAgentProjectFlowPalette;
     private final PatchAgentProjectApiMapper patchAgentProjectApiMapper;
     private final PatchAgentProject patchAgentProject;
     private final DeleteAgentProject deleteAgentProject;
@@ -69,6 +77,20 @@ public class AgentProjectController implements AgentProjectApi {
     public ResponseEntity<AgentProjectDTO> getAgentProject(final UUID projectId) {
         final AgentProject response = this.getAgentProject.execute(projectId);
         return ResponseEntity.ok(this.agentApiMapper.asAgentProjectDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentProjectFlowResponseDTO> getAgentProjectFlow(final UUID projectId) {
+        final AgentProjectFlow response = this.getAgentProjectFlow.execute(projectId);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentProjectFlowResponseDto(response));
+    }
+
+    @Override
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AgentProjectFlowPaletteResponseDTO> getAgentProjectFlowPalette(final UUID projectId) {
+        final AgentProjectFlowPaletteResponse response = this.getAgentProjectFlowPalette.execute(projectId);
+        return ResponseEntity.ok(this.agentApiMapper.asAgentProjectFlowPaletteResponseDto(response));
     }
 
     @Override

--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/AgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/AgentApiMapper.java
@@ -2,6 +2,12 @@ package com.sitionix.bffssox.mapper;
 
 import com.app_afesox.bffssox.api_first.dto.AgentDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowEdgeDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowNodeDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowNodePositionDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowPaletteResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowPaletteSourceDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentsResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AddAgentToProjectRequestDTO;
@@ -9,6 +15,12 @@ import com.app_afesox.bffssox.api_first.dto.ProjectAgentResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ProjectAgentsResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowEdge;
+import com.sitionix.bffssox.domain.AgentProjectFlowNode;
+import com.sitionix.bffssox.domain.AgentProjectFlowNodePosition;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteSource;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
@@ -32,4 +44,16 @@ public interface AgentApiMapper {
     ProjectAgentResponseDTO asProjectAgentResponseDto(ProjectAgent src);
 
     ProjectAgentsResponseDTO asProjectAgentsResponseDto(ProjectAgentsResponse src);
+
+    AgentProjectFlowResponseDTO asAgentProjectFlowResponseDto(AgentProjectFlow src);
+
+    AgentProjectFlowNodeDTO asAgentProjectFlowNodeDto(AgentProjectFlowNode src);
+
+    AgentProjectFlowNodePositionDTO asAgentProjectFlowNodePositionDto(AgentProjectFlowNodePosition src);
+
+    AgentProjectFlowEdgeDTO asAgentProjectFlowEdgeDto(AgentProjectFlowEdge src);
+
+    AgentProjectFlowPaletteResponseDTO asAgentProjectFlowPaletteResponseDto(AgentProjectFlowPaletteResponse src);
+
+    AgentProjectFlowPaletteSourceDTO asAgentProjectFlowPaletteSourceDto(AgentProjectFlowPaletteSource src);
 }

--- a/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentProjectControllerTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/controller/AgentProjectControllerTest.java
@@ -1,6 +1,8 @@
 package com.sitionix.bffssox.controller;
 
 import com.app_afesox.bffssox.api_first.dto.AgentProjectDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowPaletteResponseDTO;
+import com.app_afesox.bffssox.api_first.dto.AgentProjectFlowResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AgentProjectsPageResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.AddAgentToProjectRequestDTO;
 import com.app_afesox.bffssox.api_first.dto.CreateAgentProjectRequestDTO;
@@ -9,6 +11,8 @@ import com.app_afesox.bffssox.api_first.dto.ProjectAgentResponseDTO;
 import com.app_afesox.bffssox.api_first.dto.ProjectAgentsResponseDTO;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
 import com.sitionix.bffssox.domain.PatchAgentProjectRequest;
@@ -21,6 +25,8 @@ import com.sitionix.bffssox.usecase.AddAgentToProject;
 import com.sitionix.bffssox.usecase.CreateAgentProject;
 import com.sitionix.bffssox.usecase.DeleteAgentProject;
 import com.sitionix.bffssox.usecase.GetAgentProject;
+import com.sitionix.bffssox.usecase.GetAgentProjectFlow;
+import com.sitionix.bffssox.usecase.GetAgentProjectFlowPalette;
 import com.sitionix.bffssox.usecase.GetAgentProjects;
 import com.sitionix.bffssox.usecase.GetProjectAgents;
 import com.sitionix.bffssox.usecase.PatchAgentProject;
@@ -51,6 +57,8 @@ class AgentProjectControllerTest {
     @Mock private CreateAgentProject createAgentProject;
     @Mock private GetAgentProjects getAgentProjects;
     @Mock private GetAgentProject getAgentProject;
+    @Mock private GetAgentProjectFlow getAgentProjectFlow;
+    @Mock private GetAgentProjectFlowPalette getAgentProjectFlowPalette;
     @Mock private PatchAgentProjectApiMapper patchAgentProjectApiMapper;
     @Mock private PatchAgentProject patchAgentProject;
     @Mock private DeleteAgentProject deleteAgentProject;
@@ -61,7 +69,7 @@ class AgentProjectControllerTest {
     @BeforeEach
     void setUp() {
         this.agentProjectController = new AgentProjectController(this.createAgentProjectApiMapper, this.agentApiMapper,
-                this.createAgentProject, this.getAgentProjects, this.getAgentProject,
+                this.createAgentProject, this.getAgentProjects, this.getAgentProject, this.getAgentProjectFlow, this.getAgentProjectFlowPalette,
                 this.patchAgentProjectApiMapper, this.patchAgentProject, this.deleteAgentProject, this.getProjectAgents,
                 this.addAgentToProject, this.removeAgentFromProject);
     }
@@ -69,6 +77,7 @@ class AgentProjectControllerTest {
     @AfterEach
     void tearDown() {
         verifyNoMoreInteractions(this.createAgentProjectApiMapper, this.agentApiMapper, this.createAgentProject, this.getAgentProjects, this.getAgentProject,
+                this.getAgentProjectFlow, this.getAgentProjectFlowPalette,
                 this.patchAgentProjectApiMapper, this.patchAgentProject, this.deleteAgentProject, this.getProjectAgents, this.addAgentToProject,
                 this.removeAgentFromProject);
     }
@@ -127,6 +136,42 @@ class AgentProjectControllerTest {
         assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
         verify(this.getAgentProject).execute(projectId);
         verify(this.agentApiMapper).asAgentProjectDto(response);
+    }
+
+    @Test
+    void givenProjectId_whenGetAgentProjectFlow_thenReturnFlowDto() {
+        //given
+        final UUID projectId = UUID.randomUUID();
+        final AgentProjectFlow response = mock(AgentProjectFlow.class);
+        final AgentProjectFlowResponseDTO responseDto = mock(AgentProjectFlowResponseDTO.class);
+        when(this.getAgentProjectFlow.execute(projectId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentProjectFlowResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentProjectFlowResponseDTO> actual = this.agentProjectController.getAgentProjectFlow(projectId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentProjectFlow).execute(projectId);
+        verify(this.agentApiMapper).asAgentProjectFlowResponseDto(response);
+    }
+
+    @Test
+    void givenProjectId_whenGetAgentProjectFlowPalette_thenReturnFlowPaletteDto() {
+        //given
+        final UUID projectId = UUID.randomUUID();
+        final AgentProjectFlowPaletteResponse response = mock(AgentProjectFlowPaletteResponse.class);
+        final AgentProjectFlowPaletteResponseDTO responseDto = mock(AgentProjectFlowPaletteResponseDTO.class);
+        when(this.getAgentProjectFlowPalette.execute(projectId)).thenReturn(response);
+        when(this.agentApiMapper.asAgentProjectFlowPaletteResponseDto(response)).thenReturn(responseDto);
+
+        //when
+        final ResponseEntity<AgentProjectFlowPaletteResponseDTO> actual = this.agentProjectController.getAgentProjectFlowPalette(projectId);
+
+        //then
+        assertThat(actual).isEqualTo(ResponseEntity.ok(responseDto));
+        verify(this.getAgentProjectFlowPalette).execute(projectId);
+        verify(this.agentApiMapper).asAgentProjectFlowPaletteResponseDto(response);
     }
 
     @Test

--- a/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlowImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlowImpl.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentProjectClient;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetAgentProjectFlowImpl implements GetAgentProjectFlow {
+
+    private final AgentProjectClient agentProjectClient;
+
+    @Override
+    public AgentProjectFlow execute(final UUID projectId) {
+        return this.agentProjectClient.getAgentProjectFlow(projectId);
+    }
+}

--- a/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlowPaletteImpl.java
+++ b/application/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlowPaletteImpl.java
@@ -1,0 +1,19 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.client.AgentProjectClient;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetAgentProjectFlowPaletteImpl implements GetAgentProjectFlowPalette {
+
+    private final AgentProjectClient agentProjectClient;
+
+    @Override
+    public AgentProjectFlowPaletteResponse execute(final UUID projectId) {
+        return this.agentProjectClient.getAgentProjectFlowPalette(projectId);
+    }
+}

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
@@ -21,17 +21,15 @@
       "createdAt": "2026-04-21T10:01:00Z"
     }
   ],
-  "executions": [
-    {
-      "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
-      "conversationId": "11111111-1111-1111-1111-111111111111",
-      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
-      "status": "IN_PROGRESS",
-      "acceptedAt": "2026-04-21T10:01:05Z",
-      "startedAt": "2026-04-21T10:01:06Z",
-      "completedAt": null,
-      "error": null,
-      "assistantMessage": null
-    }
-  ]
+  "execution": {
+    "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+    "conversationId": "11111111-1111-1111-1111-111111111111",
+    "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+    "status": "IN_PROGRESS",
+    "acceptedAt": "2026-04-21T10:01:05Z",
+    "startedAt": "2026-04-21T10:01:06Z",
+    "completedAt": null,
+    "error": null,
+    "assistantMessage": null
+  }
 }

--- a/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
@@ -21,17 +21,15 @@
       "createdAt": "2026-04-21T10:01:00Z"
     }
   ],
-  "executions": [
-    {
-      "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
-      "conversationId": "11111111-1111-1111-1111-111111111111",
-      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
-      "status": "IN_PROGRESS",
-      "acceptedAt": "2026-04-21T10:01:05Z",
-      "startedAt": "2026-04-21T10:01:06Z",
-      "completedAt": null,
-      "error": null,
-      "assistantMessage": null
-    }
-  ]
+  "execution": {
+    "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+    "conversationId": "11111111-1111-1111-1111-111111111111",
+    "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+    "status": "IN_PROGRESS",
+    "acceptedAt": "2026-04-21T10:01:05Z",
+    "startedAt": "2026-04-21T10:01:06Z",
+    "completedAt": null,
+    "error": null,
+    "assistantMessage": null
+  }
 }

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.27</atmssox.api.version>
+        <atmssox.api.version>0.0.29</atmssox.api.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.afesox</groupId>
-            <artifactId>app-afesox-atmssox-client-stable</artifactId>
+            <artifactId>app-afesox-atmssox-client-sitionix-140-unstable</artifactId>
             <version>${atmssox.api.version}</version>
         </dependency>
         <dependency>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClient.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClient.java
@@ -3,6 +3,8 @@ package com.sitionix.bffssox.client;
 import com.app_afesox.atmssox.client.api.AgentProjectApi;
 import com.app_afesox.atmssox.client.dto.AddAgentToProjectRequestDTO;
 import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowPaletteResponseDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentProjectsPageResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentProjectRequestDTO;
 import com.app_afesox.atmssox.client.dto.PatchAgentProjectRequestDTO;
@@ -10,6 +12,8 @@ import com.app_afesox.atmssox.client.dto.ProjectAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.ProjectAgentsResponseDTO;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
 import com.sitionix.bffssox.domain.PatchAgentProjectRequest;
@@ -86,5 +90,21 @@ public class AgentProjectAtmssoxClient implements AgentProjectClient {
             this.agentProjectApi.removeAgentFromProject(projectId, agentId);
             return null;
         });
+    }
+
+    @Override
+    public AgentProjectFlow getAgentProjectFlow(final UUID projectId) {
+        final AgentProjectFlowResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentProjectApi.getAgentProjectFlow(projectId)
+        );
+        return this.agentClientMapper.asAgentProjectFlow(responseDTO);
+    }
+
+    @Override
+    public AgentProjectFlowPaletteResponse getAgentProjectFlowPalette(final UUID projectId) {
+        final AgentProjectFlowPaletteResponseDTO responseDTO = this.atmssoxClientCallExecutor.execute(
+                () -> this.agentProjectApi.getAgentProjectFlowPalette(projectId)
+        );
+        return this.agentClientMapper.asAgentProjectFlowPaletteResponse(responseDTO);
     }
 }

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/AgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/AgentClientMapper.java
@@ -2,6 +2,12 @@ package com.sitionix.bffssox.mapper;
 
 import com.app_afesox.atmssox.client.dto.AgentDTO;
 import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowEdgeDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowNodeDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowNodePositionDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowPaletteResponseDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowPaletteSourceDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentProjectsPageResponseDTO;
 import com.app_afesox.atmssox.client.dto.AgentsResponseDTO;
 import com.app_afesox.atmssox.client.dto.AddAgentToProjectRequestDTO;
@@ -9,6 +15,12 @@ import com.app_afesox.atmssox.client.dto.ProjectAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.ProjectAgentsResponseDTO;
 import com.sitionix.bffssox.domain.Agent;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowEdge;
+import com.sitionix.bffssox.domain.AgentProjectFlowNode;
+import com.sitionix.bffssox.domain.AgentProjectFlowNodePosition;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteSource;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.AgentsResponse;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
@@ -32,4 +44,16 @@ public interface AgentClientMapper {
     ProjectAgent asProjectAgent(ProjectAgentResponseDTO src);
 
     ProjectAgentsResponse asProjectAgentsResponse(ProjectAgentsResponseDTO src);
+
+    AgentProjectFlow asAgentProjectFlow(AgentProjectFlowResponseDTO src);
+
+    AgentProjectFlowNode asAgentProjectFlowNode(AgentProjectFlowNodeDTO src);
+
+    AgentProjectFlowNodePosition asAgentProjectFlowNodePosition(AgentProjectFlowNodePositionDTO src);
+
+    AgentProjectFlowEdge asAgentProjectFlowEdge(AgentProjectFlowEdgeDTO src);
+
+    AgentProjectFlowPaletteResponse asAgentProjectFlowPaletteResponse(AgentProjectFlowPaletteResponseDTO src);
+
+    AgentProjectFlowPaletteSource asAgentProjectFlowPaletteSource(AgentProjectFlowPaletteSourceDTO src);
 }

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -32,6 +32,7 @@ import com.sitionix.bffssox.domain.ProjectConversationParticipant;
 import com.sitionix.bffssox.domain.ProjectConversationProject;
 import com.sitionix.bffssox.domain.ProjectConversationsResponse;
 import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.mapstruct.InjectionStrategy;
@@ -81,8 +82,15 @@ public interface ChatAgentClientMapper {
 
     @Mapping(target = "type", source = "type")
     @Mapping(target = "messages", source = "messages")
-    @Mapping(target = "executions", source = "executions")
+    @Mapping(target = "executions", expression = "java(mapExecutions(src.getExecution()))")
     AgentConversationDetails asAgentConversationDetails(AgentConversationDetailsDTO src);
+
+    default List<ChatExecution> mapExecutions(final ChatExecutionDTO execution) {
+        if (execution == null) {
+            return Collections.emptyList();
+        }
+        return List.of(this.asChatExecution(execution));
+    }
 
     default String map(final AgentConversationDetailsDTO.TypeEnum value) {
         return value == null ? null : value.getValue();

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClientTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/client/AgentProjectAtmssoxClientTest.java
@@ -3,12 +3,16 @@ package com.sitionix.bffssox.client;
 import com.app_afesox.atmssox.client.api.AgentProjectApi;
 import com.app_afesox.atmssox.client.dto.AddAgentToProjectRequestDTO;
 import com.app_afesox.atmssox.client.dto.AgentProjectDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowPaletteResponseDTO;
+import com.app_afesox.atmssox.client.dto.AgentProjectFlowResponseDTO;
 import com.app_afesox.atmssox.client.dto.CreateAgentProjectRequestDTO;
 import com.app_afesox.atmssox.client.dto.PatchAgentProjectRequestDTO;
 import com.app_afesox.atmssox.client.dto.ProjectAgentResponseDTO;
 import com.app_afesox.atmssox.client.dto.ProjectAgentsResponseDTO;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
 import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
 import com.sitionix.bffssox.domain.PatchAgentProjectRequest;
 import com.sitionix.bffssox.domain.ProjectAgent;
@@ -183,5 +187,45 @@ class AgentProjectAtmssoxClientTest {
         //then
         verify(this.atmssoxClientCallExecutor).execute(any());
         verify(this.agentProjectApi).removeAgentFromProject(projectId, agentId);
+    }
+
+    @Test
+    void givenProjectId_whenGetAgentProjectFlow_thenReturnMappedFlow() {
+        //given
+        final UUID projectId = UUID.randomUUID();
+        final AgentProjectFlowResponseDTO responseDTO = mock(AgentProjectFlowResponseDTO.class);
+        final AgentProjectFlow expected = mock(AgentProjectFlow.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentProjectFlowResponseDTO>) invocation.getArgument(0)).get());
+        when(this.agentProjectApi.getAgentProjectFlow(projectId)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgentProjectFlow(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentProjectFlow actual = this.agentProjectAtmssoxClient.getAgentProjectFlow(projectId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentProjectApi).getAgentProjectFlow(projectId);
+        verify(this.agentClientMapper).asAgentProjectFlow(responseDTO);
+    }
+
+    @Test
+    void givenProjectId_whenGetAgentProjectFlowPalette_thenReturnMappedPalette() {
+        //given
+        final UUID projectId = UUID.randomUUID();
+        final AgentProjectFlowPaletteResponseDTO responseDTO = mock(AgentProjectFlowPaletteResponseDTO.class);
+        final AgentProjectFlowPaletteResponse expected = mock(AgentProjectFlowPaletteResponse.class);
+        when(this.atmssoxClientCallExecutor.execute(any())).thenAnswer(invocation -> ((Supplier<AgentProjectFlowPaletteResponseDTO>) invocation.getArgument(0)).get());
+        when(this.agentProjectApi.getAgentProjectFlowPalette(projectId)).thenReturn(responseDTO);
+        when(this.agentClientMapper.asAgentProjectFlowPaletteResponse(responseDTO)).thenReturn(expected);
+
+        //when
+        final AgentProjectFlowPaletteResponse actual = this.agentProjectAtmssoxClient.getAgentProjectFlowPalette(projectId);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+        verify(this.atmssoxClientCallExecutor).execute(any());
+        verify(this.agentProjectApi).getAgentProjectFlowPalette(projectId);
+        verify(this.agentClientMapper).asAgentProjectFlowPaletteResponse(responseDTO);
     }
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -533,7 +533,7 @@ class ChatAgentClientMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
-                .executions(executions)
+                .execution(executions == null || executions.isEmpty() ? null : executions.getFirst())
                 .build();
     }
 

--- a/domain/src/main/java/com/sitionix/bffssox/client/AgentProjectClient.java
+++ b/domain/src/main/java/com/sitionix/bffssox/client/AgentProjectClient.java
@@ -1,6 +1,8 @@
 package com.sitionix.bffssox.client;
 
 import com.sitionix.bffssox.domain.AgentProject;
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
 import com.sitionix.bffssox.domain.AgentProjectsPageResponse;
 import com.sitionix.bffssox.domain.AddAgentToProjectRequest;
 import com.sitionix.bffssox.domain.CreateAgentProjectRequest;
@@ -29,4 +31,8 @@ public interface AgentProjectClient {
     ProjectAgent addAgentToProject(UUID projectId, AddAgentToProjectRequest request);
 
     void removeAgentFromProject(UUID projectId, UUID agentId);
+
+    AgentProjectFlow getAgentProjectFlow(UUID projectId);
+
+    AgentProjectFlowPaletteResponse getAgentProjectFlowPalette(UUID projectId);
 }

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlow.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlow.java
@@ -1,0 +1,17 @@
+package com.sitionix.bffssox.domain;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AgentProjectFlow {
+
+    private UUID flowId;
+
+    private List<AgentProjectFlowNode> nodes;
+
+    private List<AgentProjectFlowEdge> edges;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowEdge.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowEdge.java
@@ -1,0 +1,21 @@
+package com.sitionix.bffssox.domain;
+
+import java.util.Map;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AgentProjectFlowEdge {
+
+    private UUID id;
+
+    private UUID sourceNodeId;
+
+    private UUID targetNodeId;
+
+    private String edgeType;
+
+    private Map<String, Object> config;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowNode.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowNode.java
@@ -1,0 +1,23 @@
+package com.sitionix.bffssox.domain;
+
+import java.util.Map;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AgentProjectFlowNode {
+
+    private UUID id;
+
+    private String nodeType;
+
+    private UUID referenceId;
+
+    private AgentProjectFlowNodePosition position;
+
+    private String designStatus;
+
+    private Map<String, Object> config;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowNodePosition.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowNodePosition.java
@@ -1,0 +1,13 @@
+package com.sitionix.bffssox.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AgentProjectFlowNodePosition {
+
+    private Double x;
+
+    private Double y;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowPaletteResponse.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowPaletteResponse.java
@@ -1,0 +1,12 @@
+package com.sitionix.bffssox.domain;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AgentProjectFlowPaletteResponse {
+
+    private List<AgentProjectFlowPaletteSource> sources;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowPaletteSource.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentProjectFlowPaletteSource.java
@@ -1,0 +1,16 @@
+package com.sitionix.bffssox.domain;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AgentProjectFlowPaletteSource {
+
+    private String sourceType;
+
+    private UUID sourceId;
+
+    private String sourceName;
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlow.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlow.java
@@ -1,0 +1,9 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.AgentProjectFlow;
+import java.util.UUID;
+
+public interface GetAgentProjectFlow {
+
+    AgentProjectFlow execute(UUID projectId);
+}

--- a/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlowPalette.java
+++ b/domain/src/main/java/com/sitionix/bffssox/usecase/GetAgentProjectFlowPalette.java
@@ -1,0 +1,9 @@
+package com.sitionix.bffssox.usecase;
+
+import com.sitionix.bffssox.domain.AgentProjectFlowPaletteResponse;
+import java.util.UUID;
+
+public interface GetAgentProjectFlowPalette {
+
+    AgentProjectFlowPaletteResponse execute(UUID projectId);
+}


### PR DESCRIPTION
## Summary
- expose GET /api/v1/agent-projects/{projectId}/flow in BFF facade
- expose GET /api/v1/agent-projects/{projectId}/flow/palette in BFF facade
- keep flow and palette retrieval independent with existing ErrorDTO mapping path
- align BFF/ATMS generated dependencies for SITIONIX-140 and update compatibility mappings/tests

## Verification
- mvn clean install (BUILD SUCCESS)
