### PR TITLE
[SITIONIX-139] - Align execution field for atmssox client v0.0.28

### DIFF
--- a/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
+++ b/api-rest/src/main/java/com/sitionix/bffssox/mapper/ChatAgentApiMapper.java
@@ -80,7 +80,7 @@ public interface ChatAgentApiMapper {
     AgentConversationsResponseDTO asAgentConversationsResponseDto(AgentConversationsResponse src);
 
     @Mapping(target = "messages", source = "messages")
-    @Mapping(target = "execution", source = "executions")
+    @Mapping(target = "execution", source = "execution")
     AgentConversationDetailsDTO asAgentConversationDetailsDto(AgentConversationDetails src);
 
     default AgentConversationDetailsDTO.TypeEnum map(final String value) {
@@ -131,13 +131,6 @@ public interface ChatAgentApiMapper {
 
     default ProjectConversationParticipantDTO.StatusEnum mapProjectConversationParticipantStatus(final String value) {
         return value == null ? null : ProjectConversationParticipantDTO.StatusEnum.fromValue(value);
-    }
-
-    default ChatExecutionDTO mapExecution(final List<ChatExecution> executions) {
-        if (executions == null || executions.isEmpty()) {
-            return null;
-        }
-        return this.asChatExecutionDto(executions.get(0));
     }
 
     default ExecutionStatusDTO mapSubmitExecutionStatus(final String value, final Boolean runtimeDispatched) {

--- a/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
+++ b/api-rest/src/test/java/com/sitionix/bffssox/mapper/ChatAgentApiMapperTest.java
@@ -35,7 +35,6 @@ import com.sitionix.bffssox.domain.ProjectConversationsResponse;
 import com.sitionix.bffssox.domain.SubmitConversationExecutionResponse;
 import com.sitionix.bffssox.domain.SubmitChatExecutionResponse;
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -178,7 +177,7 @@ class ChatAgentApiMapperTest {
                         "Clean architecture separates business logic.",
                         createdAt
                 )),
-                List.of(this.getFailedChatExecution())
+                this.getFailedChatExecution()
         );
         final AgentConversationDetailsDTO expected = this.getAgentConversationDetailsDto(
                 UUID.fromString("11111111-1111-1111-1111-111111111111"),
@@ -336,30 +335,6 @@ class ChatAgentApiMapperTest {
 
         //then
         assertThat(actual).isEqualTo(ExecutionStatusDTO.SUCCEEDED);
-    }
-
-    @Test
-    void givenNullExecutions_whenMapExecution_thenReturnNull() {
-        //given
-        final List<ChatExecution> executions = null;
-
-        //when
-        final ChatExecutionDTO actual = this.mapper.mapExecution(executions);
-
-        //then
-        assertThat(actual).isNull();
-    }
-
-    @Test
-    void givenEmptyExecutions_whenMapExecution_thenReturnNull() {
-        //given
-        final List<ChatExecution> executions = Collections.emptyList();
-
-        //when
-        final ChatExecutionDTO actual = this.mapper.mapExecution(executions);
-
-        //then
-        assertThat(actual).isNull();
     }
 
     @Test
@@ -529,7 +504,7 @@ class ChatAgentApiMapperTest {
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
             final List<ChatAgentMessage> messages,
-            final List<ChatExecution> executions
+            final ChatExecution execution
     ) {
         return AgentConversationDetails.builder()
                 .id(id)
@@ -539,7 +514,7 @@ class ChatAgentApiMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
-                .executions(executions)
+                .execution(execution)
                 .build();
     }
 

--- a/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/default/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
@@ -21,17 +21,15 @@
       "createdAt": "2026-04-21T10:01:00Z"
     }
   ],
-  "executions": [
-    {
-      "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
-      "conversationId": "11111111-1111-1111-1111-111111111111",
-      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
-      "status": "IN_PROGRESS",
-      "acceptedAt": "2026-04-21T10:01:05Z",
-      "startedAt": "2026-04-21T10:01:06Z",
-      "completedAt": null,
-      "error": null,
-      "assistantMessage": null
-    }
-  ]
+  "execution": {
+    "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+    "conversationId": "11111111-1111-1111-1111-111111111111",
+    "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+    "status": "IN_PROGRESS",
+    "acceptedAt": "2026-04-21T10:01:05Z",
+    "startedAt": "2026-04-21T10:01:06Z",
+    "completedAt": null,
+    "error": null,
+    "assistantMessage": null
+  }
 }

--- a/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
+++ b/boot/src/test/resources/forge-it/wiremock/response/responseDefaultMappingGetAgentConversationWithExecutionInProgress.json
@@ -21,17 +21,15 @@
       "createdAt": "2026-04-21T10:01:00Z"
     }
   ],
-  "executions": [
-    {
-      "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
-      "conversationId": "11111111-1111-1111-1111-111111111111",
-      "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
-      "status": "IN_PROGRESS",
-      "acceptedAt": "2026-04-21T10:01:05Z",
-      "startedAt": "2026-04-21T10:01:06Z",
-      "completedAt": null,
-      "error": null,
-      "assistantMessage": null
-    }
-  ]
+  "execution": {
+    "executionId": "d8827667-03f3-4d46-ae0d-d35e43ecdf95",
+    "conversationId": "11111111-1111-1111-1111-111111111111",
+    "agentId": "4e0c95eb-9e63-4b3f-98f4-2c8c713233c0",
+    "status": "IN_PROGRESS",
+    "acceptedAt": "2026-04-21T10:01:05Z",
+    "startedAt": "2026-04-21T10:01:06Z",
+    "completedAt": null,
+    "error": null,
+    "assistantMessage": null
+  }
 }

--- a/clients/client-atmssox/pom.xml
+++ b/clients/client-atmssox/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>client-atmssox</artifactId>
 
     <properties>
-        <atmssox.api.version>0.0.27</atmssox.api.version>
+        <atmssox.api.version>0.0.28</atmssox.api.version>
     </properties>
 
     <dependencies>

--- a/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
+++ b/clients/client-atmssox/src/main/java/com/sitionix/bffssox/mapper/ChatAgentClientMapper.java
@@ -81,7 +81,7 @@ public interface ChatAgentClientMapper {
 
     @Mapping(target = "type", source = "type")
     @Mapping(target = "messages", source = "messages")
-    @Mapping(target = "executions", source = "executions")
+    @Mapping(target = "execution", source = "execution")
     AgentConversationDetails asAgentConversationDetails(AgentConversationDetailsDTO src);
 
     default String map(final AgentConversationDetailsDTO.TypeEnum value) {
@@ -149,4 +149,5 @@ public interface ChatAgentClientMapper {
             default -> value.getValue();
         };
     }
+
 }

--- a/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
+++ b/clients/client-atmssox/src/test/java/com/sitionix/bffssox/mapper/ChatAgentClientMapperTest.java
@@ -187,7 +187,7 @@ class ChatAgentClientMapperTest {
                         "Clean architecture separates business logic.",
                         createdAt
                 )),
-                List.of(this.getFailedChatExecutionDto())
+                this.getFailedChatExecutionDto()
         );
         final AgentConversationDetails expected = this.getAgentConversationDetails(
                 UUID.fromString("11111111-1111-1111-1111-111111111111"),
@@ -202,7 +202,7 @@ class ChatAgentClientMapperTest {
                         "Clean architecture separates business logic.",
                         createdAt
                 )),
-                List.of(this.getFailedChatExecution())
+                this.getFailedChatExecution()
         );
 
         //when
@@ -523,7 +523,7 @@ class ChatAgentClientMapperTest {
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
             final List<AgentConversationMessageDTO> messages,
-            final List<ChatExecutionDTO> executions
+            final ChatExecutionDTO execution
     ) {
         return AgentConversationDetailsDTO.builder()
                 .id(id)
@@ -533,7 +533,7 @@ class ChatAgentClientMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
-                .executions(executions)
+                .execution(execution)
                 .build();
     }
 
@@ -544,7 +544,7 @@ class ChatAgentClientMapperTest {
             final OffsetDateTime createdAt,
             final OffsetDateTime updatedAt,
             final List<ChatAgentMessage> messages,
-            final List<ChatExecution> executions
+            final ChatExecution execution
     ) {
         return AgentConversationDetails.builder()
                 .id(id)
@@ -554,7 +554,7 @@ class ChatAgentClientMapperTest {
                 .updatedAt(updatedAt)
                 .lastMessageAt(updatedAt)
                 .messages(messages)
-                .executions(executions)
+                .execution(execution)
                 .build();
     }
 

--- a/domain/src/main/java/com/sitionix/bffssox/domain/AgentConversationDetails.java
+++ b/domain/src/main/java/com/sitionix/bffssox/domain/AgentConversationDetails.java
@@ -24,5 +24,5 @@ public class AgentConversationDetails {
 
     private List<ChatAgentMessage> messages;
 
-    private List<ChatExecution> executions;
+    private ChatExecution execution;
 }


### PR DESCRIPTION
## Summary
- bump `app-afesox-atmssox-client-stable` to `0.0.28`
- align BFF conversation execution model and mappers with generated `execution` field (singular)
- update mapper unit tests and Forge IT wiremock fixtures to new payload shape

## Validation
- `mvn clean install` (full reactor)